### PR TITLE
Add standardized README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # OpenAdapt Evals
 
+[![Build Status](https://github.com/OpenAdaptAI/openadapt-evals/workflows/Publish%20to%20PyPI/badge.svg?branch=main)](https://github.com/OpenAdaptAI/openadapt-evals/actions)
+[![PyPI version](https://img.shields.io/pypi/v/openadapt-evals.svg)](https://pypi.org/project/openadapt-evals/)
+[![Downloads](https://img.shields.io/pypi/dm/openadapt-evals.svg)](https://pypi.org/project/openadapt-evals/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
+
 Evaluation infrastructure for GUI agent benchmarks.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Add build status badge linking to GitHub Actions
- Add PyPI version badge
- Add PyPI downloads badge
- Add MIT license badge
- Add Python 3.10+ version badge

These badges provide at-a-glance visibility into the package status and are standardized across all OpenAdaptAI repositories.

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Verify badge links work correctly

Generated with [Claude Code](https://claude.com/claude-code)