### PR TITLE
fix: Use filename-based GitHub Actions badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenAdapt Evals
 
-[![Build Status](https://github.com/OpenAdaptAI/openadapt-evals/workflows/Publish%20to%20PyPI/badge.svg?branch=main)](https://github.com/OpenAdaptAI/openadapt-evals/actions)
+[![Build Status](https://github.com/OpenAdaptAI/openadapt-evals/actions/workflows/publish.yml/badge.svg)](https://github.com/OpenAdaptAI/openadapt-evals/actions/workflows/publish.yml)
 [![PyPI version](https://img.shields.io/pypi/v/openadapt-evals.svg)](https://pypi.org/project/openadapt-evals/)
 [![Downloads](https://img.shields.io/pypi/dm/openadapt-evals.svg)](https://pypi.org/project/openadapt-evals/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary
- Changed the GitHub Actions badge URL from workflow-name format to filename-based format
- The workflow-name-based URL (`workflows/Publish%20to%20PyPI/badge.svg`) may show "no status"
- The filename-based URL (`actions/workflows/publish.yml/badge.svg`) is more reliable

## Test plan
- [x] Verified the new badge URL format is correct by checking GitHub documentation
- [ ] Badge should show workflow status after PR is merged

Generated with [Claude Code](https://claude.com/claude-code)