### PR TITLE
docs: replace aspirational claims with honest placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The following features are under active development:
 
 ### Azure Reliability (`[IN PROGRESS]`)
 - **Goal**: 95%+ task completion rate (vs. early issues with 0%)
-- **VM Configuration**: Using `Standard_D8ds_v5` with nested virtualization
+- **VM Configuration**: Using `Standard_D4s_v5` with nested virtualization (configurable)
 - **Health Monitoring**: Automatic detection and retry of stuck jobs
 
 ### Cost Optimization (`[IN PROGRESS]`)
@@ -322,8 +322,8 @@ results = evaluate_agent_on_benchmark(agent, adapter, task_ids=[t.task_id for t 
 Run WAA at scale using Azure ML compute with optimized costs:
 
 > **⚠️ Quota Requirements**: Parallel evaluation requires sufficient Azure vCPU quota.
-> - Each worker needs a `Standard_D8ds_v5` VM (8 vCPUs)
-> - 10 workers = 80 vCPUs required
+> - Default VM: `Standard_D4s_v5` (4 vCPUs per worker)
+> - 10 workers = 40 vCPUs required
 > - Default quota is typically 10 vCPUs - [request an increase](https://learn.microsoft.com/en-us/azure/quotas/quickstart-increase-quota-portal) before running parallel evaluations
 
 ```bash
@@ -366,7 +366,7 @@ results = orchestrator.run_evaluation(
 )
 ```
 
-**Azure Reliability**: The orchestrator uses `Standard_D8ds_v5` VMs with nested virtualization support and automatic health monitoring.
+**Azure Reliability**: The orchestrator uses `Standard_D4s_v5` VMs with nested virtualization support and automatic health monitoring.
 
 ### Live Monitoring
 


### PR DESCRIPTION
## Summary

- Remove unvalidated badges (95%+ success rate, 67% cost savings)
- Add "First open-source WAA reproduction" as headline
- Move WAA to top as main feature with status indicator
- Change "Recent Improvements" to "Roadmap (In Progress)"
- Remove v0.2.0 version references (current is v0.1.1)
- Add Azure quota requirements note for parallelization
- Mark features as `[IN PROGRESS]` where appropriate

## Context

The README had aspirational claims (95%+ success rate, 67% cost savings, v0.2.0 features) that were not yet validated. This PR makes the README honest by:

1. Removing badges that implied completed work
2. Clearly marking in-progress features as such
3. Adding "Results coming soon" status indicator
4. Noting Azure quota requirements users need to know

## Test plan

- [x] Verify README renders correctly on GitHub
- [x] All links work
- [x] No broken badge references

🤖 Generated with [Claude Code](https://claude.ai/code)