### PR TITLE
fix(recording): replace busy-wait loop with time.sleep

### DIFF
--- a/scripts/record_waa_demos.py
+++ b/scripts/record_waa_demos.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 # WAA tasks to record
@@ -171,9 +172,9 @@ def record_task(task: dict, recordings_dir: Path) -> Path | None:
             capture_audio=False,
         ) as recorder:
             try:
-                # Wait for Ctrl+C
+                # Wait for Ctrl+C (sleep yields CPU)
                 while True:
-                    pass
+                    time.sleep(0.5)
             except KeyboardInterrupt:
                 pass
 


### PR DESCRIPTION
## Summary

- Replace `while True: pass` with `while True: time.sleep(0.5)` in `record_waa_demos.py`
- The busy-wait loop was burning an entire CPU core during recording, contributing to system sluggishness

## Test plan

- [ ] Run `record_waa_demos.py` on Windows — CPU usage should drop significantly during recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)