### PR TITLE
docs: enforce branch protection rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # Claude Code Instructions for openadapt-evals
 
+## MANDATORY: Branches and Pull Requests
+
+**NEVER push directly to main. ALWAYS use feature branches and pull requests.**
+
+1. Create a feature branch: `git checkout -b feat/description` or `fix/description`
+2. Make commits on the branch
+3. Push the branch: `git push -u origin branch-name`
+4. Create a PR: `gh pr create --title "..." --body "..."`
+5. Only merge via PR (never `git push origin main`)
+
+This is a hard rule with NO exceptions, even for "small" changes.
+
+---
+
 ## Project Status
 
 **Before starting work**, read the project-wide status document:


### PR DESCRIPTION
## Summary
- Added mandatory branch/PR rule to CLAUDE.md
- Enabled `enforce_admins` on GitHub branch protection for both openadapt-evals and openadapt-ml repos
- This prevents any user (including admins) from pushing directly to main

## Context
Several commits were pushed directly to main in a previous session. This change ensures that can never happen again by:
1. Adding explicit instructions to CLAUDE.md (read by Claude Code at session start)
2. Enabling GitHub's `enforce_admins` flag on branch protection rules

## Tracking: Commits previously pushed to main
These commits were pushed directly to main before branch protection was enforced:
- **openadapt-evals**: `7ed1629` (PEFT adapter loading), `d85363b` (remote inference)
- **openadapt-ml**: `120c903` (Modal training fixes), `57e5c5f` (inference serving), `88e4c09` (inference image fixes)

## Test plan
- [x] Verify `enforce_admins: true` on openadapt-evals
- [x] Verify `enforce_admins: true` on openadapt-ml
- [ ] Verify direct push to main is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)