### PR TITLE
Return type=error on CU agent failures instead of type=done

### DIFF
--- a/openadapt_evals/benchmarks/runner.py
+++ b/openadapt_evals/benchmarks/runner.py
@@ -337,8 +337,11 @@ def _run_single_task(
                 config.on_step(obs, action, steps)
 
             # Check for terminal action
-            if action.type == "done":
-                logger.info(f"Step {steps}: Agent signaled task completion")
+            if action.type in ("done", "error"):
+                if action.type == "error":
+                    logger.error(f"Step {steps}: Agent error: {action.raw_action}")
+                else:
+                    logger.info(f"Step {steps}: Agent signaled task completion")
                 done = True
                 break
 
@@ -364,6 +367,11 @@ def _run_single_task(
         # Evaluate result
         logger.info("Evaluating task result")
         result = adapter.evaluate(task)
+
+        # Propagate error_type from agent error action
+        if action is not None and action.type == "error" and action.raw_action:
+            result.error_type = action.raw_action.get("error_type", "agent")
+            result.error = result.error or action.raw_action.get("reason")
 
         # Update result with trajectory info
         result.steps = history if config.save_trajectories else []


### PR DESCRIPTION
## Summary
- Early exit with type="error" when no screenshot available from environment (infrastructure failure)
- Return type="error" on API call failure instead of silently returning type="done"
- Return type="error" on retry exhaustion in screenshot/wait loop
- Runner now handles type="error" as terminal action alongside type="done"
- Runner propagates error_type from agent error action to BenchmarkResult

## Test plan
- [x] All 316 existing tests pass
- [x] Updated CU agent tests to verify new error action behavior
- [ ] Verify CU agent returns error with error_type=infrastructure when WAA is down

🤖 Generated with [Claude Code](https://claude.com/claude-code)