### PR TITLE
feat: add SmolOperatorAgent wrapping SmolVLM2-2.2B for GUI automation

### DIFF
--- a/openadapt_evals/agents/__init__.py
+++ b/openadapt_evals/agents/__init__.py
@@ -11,6 +11,7 @@ Available agents:
     - ApiAgent: Uses Claude/GPT APIs directly (for WAA)
     - ClaudeComputerUseAgent: Uses Claude's native computer_use tool
     - Qwen3VLAgent: Uses Qwen3-VL for local inference
+    - SmolOperatorAgent: Uses SmolVLM2-2.2B for local inference
     - PolicyAgent: Uses local trained policy model
     - RetrievalAugmentedAgent: Automatically retrieves demos from a library
     - BaselineAgent: Unified baselines using openadapt-ml (Claude/GPT/Gemini)
@@ -71,6 +72,9 @@ def __getattr__(name: str):
     if name == "Qwen3VLAgent":
         from openadapt_evals.agents.qwen3vl_agent import Qwen3VLAgent
         return Qwen3VLAgent
+    if name == "SmolOperatorAgent":
+        from openadapt_evals.agents.smol_agent import SmolOperatorAgent
+        return SmolOperatorAgent
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
@@ -83,6 +87,7 @@ __all__ = [
     "ApiAgent",
     "ClaudeComputerUseAgent",
     "Qwen3VLAgent",
+    "SmolOperatorAgent",
     "PolicyAgent",
     "RetrievalAugmentedAgent",
     "BaselineAgent",

--- a/openadapt_evals/agents/smol_agent.py
+++ b/openadapt_evals/agents/smol_agent.py
@@ -1,0 +1,506 @@
+"""SmolVLM2 agent for benchmark evaluation.
+
+Uses SmolVLM2-2.2B-Instruct-Agentic-GUI (Smol2Operator) for local GUI agent
+inference. Coordinates are already in [0, 1] range — no denormalization needed.
+
+The model was fine-tuned in two phases:
+  1. Stage 1: 400K grounding samples (aguvis-stage-1)
+  2. Stage 2: 784K agentic samples (aguvis-stage-2)
+
+Action space (SmolVLM2 format):
+    click(x=0.5, y=0.3)
+    double_click(x=0.5, y=0.3)
+    long_press(x=0.5, y=0.3)
+    type(text='hello world')
+    press(keys=['ctrl', 'c'])
+    scroll(direction='up', amount=10)
+    swipe(from_coord=[0.1, 0.2], to_coord=[0.8, 0.5])
+    drag(from_coord=[0.1, 0.2], to_coord=[0.8, 0.5])
+    open_app(app_name='notepad')
+    navigate_home()
+    final_answer('success')
+
+Usage:
+    from openadapt_evals.agents import SmolOperatorAgent
+
+    agent = SmolOperatorAgent()
+    action = agent.act(observation, task)
+
+    # With demo conditioning
+    agent = SmolOperatorAgent(demo="Step 0: click(x=0.45, y=0.95)...")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from openadapt_evals.adapters.base import (
+    BenchmarkAction,
+    BenchmarkObservation,
+    BenchmarkTask,
+)
+from openadapt_evals.agents.base import BenchmarkAgent
+
+logger = logging.getLogger("openadapt_evals.agents.smol")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "smolagents/SmolVLM2-2.2B-Instruct-Agentic-GUI"
+
+SYSTEM_PROMPT = (
+    "You are a helpful GUI agent that can interact with user interfaces. "
+    "Please generate the next move according to the UI screenshot, "
+    "instruction and previous actions."
+)
+
+# ---------------------------------------------------------------------------
+# Compiled regex patterns for action parsing
+# ---------------------------------------------------------------------------
+
+_FLOAT = r"[\d.]+"
+
+_RE_CLICK = re.compile(
+    r"(?<!double_)(?<!long_)click\s*\(\s*x\s*=\s*(" + _FLOAT + r")\s*,\s*y\s*=\s*(" + _FLOAT + r")\s*\)",
+    re.IGNORECASE,
+)
+_RE_DOUBLE_CLICK = re.compile(
+    r"double_click\s*\(\s*x\s*=\s*(" + _FLOAT + r")\s*,\s*y\s*=\s*(" + _FLOAT + r")\s*\)",
+    re.IGNORECASE,
+)
+_RE_LONG_PRESS = re.compile(
+    r"long_press\s*\(\s*x\s*=\s*(" + _FLOAT + r")\s*,\s*y\s*=\s*(" + _FLOAT + r")\s*\)",
+    re.IGNORECASE,
+)
+_RE_TYPE = re.compile(
+    r"type\s*\(\s*text\s*=\s*['\"](.+?)['\"]\s*\)",
+    re.IGNORECASE,
+)
+_RE_PRESS = re.compile(
+    r"press\s*\(\s*keys\s*=\s*\[([^\]]*)\]\s*\)",
+    re.IGNORECASE,
+)
+_RE_SCROLL = re.compile(
+    r"scroll\s*\(\s*direction\s*=\s*['\"](\w+)['\"]\s*"
+    r"(?:,\s*amount\s*=\s*(\d+)\s*)?\)",
+    re.IGNORECASE,
+)
+_RE_DRAG = re.compile(
+    r"drag\s*\(\s*from_coord\s*=\s*\[\s*(" + _FLOAT + r")\s*,\s*(" + _FLOAT + r")\s*\]\s*,"
+    r"\s*to_coord\s*=\s*\[\s*(" + _FLOAT + r")\s*,\s*(" + _FLOAT + r")\s*\]\s*\)",
+    re.IGNORECASE,
+)
+_RE_SWIPE = re.compile(
+    r"swipe\s*\(\s*from_coord\s*=\s*\[\s*(" + _FLOAT + r")\s*,\s*(" + _FLOAT + r")\s*\]\s*,"
+    r"\s*to_coord\s*=\s*\[\s*(" + _FLOAT + r")\s*,\s*(" + _FLOAT + r")\s*\]\s*\)",
+    re.IGNORECASE,
+)
+_RE_FINAL_ANSWER = re.compile(
+    r"final_answer\s*\(\s*['\"](.+?)['\"]\s*\)",
+    re.IGNORECASE,
+)
+_RE_OPEN_APP = re.compile(
+    r"open_app\s*\(\s*app_name\s*=\s*['\"](.+?)['\"]\s*\)",
+    re.IGNORECASE,
+)
+_RE_NAVIGATE_HOME = re.compile(r"navigate_home\s*\(\s*\)", re.IGNORECASE)
+
+_RE_THINK = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+_RE_CODE = re.compile(r"<code>(.*?)</code>", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Action parsing
+# ---------------------------------------------------------------------------
+
+
+def _extract_action_string(response: str) -> str | None:
+    """Extract the action string from model response.
+
+    SmolVLM2 Phase 2 outputs <think>...</think> followed by <code>...</code>.
+    """
+    # Try to extract from <code> block first
+    code_match = _RE_CODE.search(response)
+    if code_match:
+        return code_match.group(1).strip()
+
+    # Strip <think> blocks
+    text = _RE_THINK.sub("", response).strip()
+    if not text:
+        return None
+
+    # Take the first line that looks like a known action
+    for line in text.splitlines():
+        line = line.strip()
+        if line and re.match(
+            r"(click|double_click|long_press|type|press|scroll|drag|swipe"
+            r"|open_app|navigate_home|final_answer)\s*\(",
+            line,
+            re.IGNORECASE,
+        ):
+            return line
+
+    return text if text else None
+
+
+def parse_smol_action(
+    response: str,
+    viewport: tuple[int, int] | None = None,
+) -> BenchmarkAction:
+    """Parse SmolVLM2 action output into BenchmarkAction.
+
+    Coordinates are already in [0, 1] range — no conversion needed.
+
+    Args:
+        response: Raw model output text (may include <think>/<code> blocks).
+        viewport: Optional (width, height) stored in raw_action for reference.
+
+    Returns:
+        Parsed BenchmarkAction with coordinates in [0, 1] range.
+    """
+    raw: dict[str, Any] = {"response": response}
+    if viewport:
+        raw["viewport"] = viewport
+
+    think_match = _RE_THINK.search(response)
+    if think_match:
+        raw["thinking"] = think_match.group(1).strip()
+
+    action_str = _extract_action_string(response)
+    if action_str:
+        raw["action_string"] = action_str
+    else:
+        raw["parse_error"] = "No action found in response"
+        return BenchmarkAction(type="done", raw_action=raw)
+
+    # --- final_answer('...') → done ---
+    m = _RE_FINAL_ANSWER.search(action_str)
+    if m:
+        answer = m.group(1)
+        return BenchmarkAction(type="done", answer=answer, raw_action=raw)
+
+    # --- navigate_home() ---
+    if _RE_NAVIGATE_HOME.search(action_str):
+        return BenchmarkAction(
+            type="key", key="super", raw_action=raw
+        )
+
+    # --- double_click(x=..., y=...) --- (check before click)
+    m = _RE_DOUBLE_CLICK.search(action_str)
+    if m:
+        x, y = float(m.group(1)), float(m.group(2))
+        raw["click_variant"] = "double_click"
+        return BenchmarkAction(type="click", x=x, y=y, raw_action=raw)
+
+    # --- long_press(x=..., y=...) --- (check before click)
+    m = _RE_LONG_PRESS.search(action_str)
+    if m:
+        x, y = float(m.group(1)), float(m.group(2))
+        raw["click_variant"] = "long_press"
+        return BenchmarkAction(type="click", x=x, y=y, raw_action=raw)
+
+    # --- click(x=..., y=...) ---
+    m = _RE_CLICK.search(action_str)
+    if m:
+        x, y = float(m.group(1)), float(m.group(2))
+        return BenchmarkAction(type="click", x=x, y=y, raw_action=raw)
+
+    # --- type(text='...') ---
+    m = _RE_TYPE.search(action_str)
+    if m:
+        text = m.group(1)
+        return BenchmarkAction(type="type", text=text, raw_action=raw)
+
+    # --- press(keys=['...', ...]) ---
+    m = _RE_PRESS.search(action_str)
+    if m:
+        keys_str = m.group(1)
+        keys = [k.strip().strip("\"'") for k in keys_str.split(",") if k.strip()]
+        if len(keys) == 1:
+            return BenchmarkAction(type="key", key=keys[0], raw_action=raw)
+        elif len(keys) > 1:
+            return BenchmarkAction(
+                type="key", key=keys[-1], modifiers=keys[:-1], raw_action=raw
+            )
+        raw["parse_error"] = "Empty keys list in press()"
+        return BenchmarkAction(type="done", raw_action=raw)
+
+    # --- scroll(direction='...', amount=...) ---
+    m = _RE_SCROLL.search(action_str)
+    if m:
+        direction = m.group(1).lower()
+        amount = int(m.group(2)) if m.group(2) else 3
+        return BenchmarkAction(
+            type="scroll",
+            scroll_direction=direction,
+            scroll_amount=float(amount),
+            raw_action=raw,
+        )
+
+    # --- drag(from_coord=[...], to_coord=[...]) ---
+    m = _RE_DRAG.search(action_str)
+    if m:
+        fx, fy = float(m.group(1)), float(m.group(2))
+        tx, ty = float(m.group(3)), float(m.group(4))
+        return BenchmarkAction(
+            type="drag", x=fx, y=fy, end_x=tx, end_y=ty, raw_action=raw
+        )
+
+    # --- swipe(from_coord=[...], to_coord=[...]) → drag ---
+    m = _RE_SWIPE.search(action_str)
+    if m:
+        fx, fy = float(m.group(1)), float(m.group(2))
+        tx, ty = float(m.group(3)), float(m.group(4))
+        raw["action_variant"] = "swipe"
+        return BenchmarkAction(
+            type="drag", x=fx, y=fy, end_x=tx, end_y=ty, raw_action=raw
+        )
+
+    # --- open_app(app_name='...') → type + enter ---
+    m = _RE_OPEN_APP.search(action_str)
+    if m:
+        app_name = m.group(1)
+        raw["open_app"] = app_name
+        return BenchmarkAction(type="type", text=app_name, raw_action=raw)
+
+    # Unknown action format
+    raw["parse_error"] = f"Unknown action format: {action_str}"
+    return BenchmarkAction(type="done", raw_action=raw)
+
+
+# ---------------------------------------------------------------------------
+# Agent class
+# ---------------------------------------------------------------------------
+
+
+class SmolOperatorAgent(BenchmarkAgent):
+    """Agent using SmolVLM2-2.2B for local GUI agent inference.
+
+    Loads the model via HuggingFace transformers. Coordinates are natively
+    in [0, 1] range — no conversion needed for BenchmarkAction.
+
+    Args:
+        model_path: HuggingFace model ID or local path. Defaults to
+            ``smolagents/SmolVLM2-2.2B-Instruct-Agentic-GUI``.
+        demo: Optional demonstration text for demo-conditioned inference.
+        device: Torch device (``"cuda"``, ``"cpu"``, ``"auto"``).
+        max_new_tokens: Maximum tokens to generate per step.
+        torch_dtype: Torch dtype string.
+        image_size: Target image size for processor.
+    """
+
+    def __init__(
+        self,
+        model_path: str | None = None,
+        demo: str | None = None,
+        device: str = "auto",
+        max_new_tokens: int = 512,
+        torch_dtype: str = "auto",
+        image_size: int = 1152,
+    ):
+        self.model_path = model_path or DEFAULT_MODEL
+        self.demo = demo
+        self.device = device
+        self.max_new_tokens = max_new_tokens
+        self.torch_dtype = torch_dtype
+        self.image_size = image_size
+
+        self._previous_actions: list[str] = []
+        self._step_count = 0
+        self._model = None
+        self._processor = None
+
+        logger.info(
+            f"SmolOperatorAgent initialized: model={self.model_path}, "
+            f"device={self.device}"
+        )
+        if self.demo:
+            logger.info(f"Demo provided ({len(self.demo)} chars)")
+
+    def _load_model(self) -> None:
+        """Lazy-load model and processor on first inference call."""
+        if self._model is not None:
+            return
+
+        try:
+            import torch
+            from transformers import AutoModelForVision2Seq, AutoProcessor
+        except ImportError as e:
+            raise RuntimeError(
+                "SmolOperatorAgent requires transformers and torch. "
+                "Install with: pip install transformers torch"
+            ) from e
+
+        dtype_map = {
+            "auto": "auto",
+            "float16": torch.float16,
+            "fp16": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "bf16": torch.bfloat16,
+            "float32": torch.float32,
+            "fp32": torch.float32,
+        }
+        resolved_dtype = dtype_map.get(self.torch_dtype, "auto")
+
+        logger.info(f"Loading model: {self.model_path}")
+        self._model = AutoModelForVision2Seq.from_pretrained(
+            self.model_path,
+            torch_dtype=resolved_dtype,
+            device_map=self.device,
+        )
+        self._processor = AutoProcessor.from_pretrained(self.model_path)
+        logger.info("Model loaded successfully")
+
+    def reset(self) -> None:
+        """Reset agent state between episodes."""
+        self._step_count = 0
+        self._previous_actions = []
+        logger.debug("SmolOperatorAgent reset")
+
+    def act(
+        self,
+        observation: BenchmarkObservation,
+        task: BenchmarkTask,
+        history: list[tuple[BenchmarkObservation, BenchmarkAction]] | None = None,
+    ) -> BenchmarkAction:
+        """Given observation and task, return next action."""
+        self._load_model()
+        self._step_count += 1
+
+        image = self._get_image(observation)
+        if image is None:
+            logger.error("No screenshot available in observation")
+            return BenchmarkAction(
+                type="done", raw_action={"error": "no_screenshot"}
+            )
+
+        user_content = self._build_prompt(task.instruction)
+        messages = self._build_messages(user_content, image)
+
+        try:
+            response_text = self._run_inference(messages, image)
+        except Exception as e:
+            logger.error(f"Inference failed: {e}")
+            return BenchmarkAction(
+                type="done", raw_action={"error": f"inference_failed: {e}"}
+            )
+
+        logger.info(f"Step {self._step_count} raw response: {response_text!r}")
+
+        action = parse_smol_action(response_text, observation.viewport)
+
+        action_str = _extract_action_string(response_text)
+        if action_str:
+            self._previous_actions.append(action_str)
+
+        if action.raw_action is None:
+            action.raw_action = {}
+        action.raw_action["step"] = self._step_count
+
+        return action
+
+    def _build_prompt(self, instruction: str) -> str:
+        """Build the user-turn text."""
+        parts = [f"Instruction: {instruction}"]
+
+        if self.demo:
+            parts.append("")
+            parts.append(f"Demonstration (follow this pattern):\n{self.demo}")
+
+        if self._previous_actions:
+            parts.append("")
+            parts.append("Previous actions:")
+            for i, act in enumerate(self._previous_actions):
+                parts.append(f"  Step {i}: {act}")
+
+        parts.append("")
+        parts.append("Output exactly one action.")
+
+        return "\n".join(parts)
+
+    def _build_messages(
+        self, user_content: str, image: Any
+    ) -> list[dict[str, Any]]:
+        """Build chat messages for the SmolVLM2 processor."""
+        return [
+            {"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": user_content},
+                ],
+            },
+        ]
+
+    def _get_image(self, observation: BenchmarkObservation):
+        """Extract PIL Image from observation."""
+        from PIL import Image
+
+        screenshot_bytes = observation.screenshot
+        if screenshot_bytes is None and observation.screenshot_path:
+            try:
+                screenshot_bytes = Path(observation.screenshot_path).read_bytes()
+            except (FileNotFoundError, OSError):
+                pass
+
+        if screenshot_bytes is None:
+            return None
+
+        try:
+            img = Image.open(BytesIO(screenshot_bytes)).convert("RGB")
+            # Resize to target size while maintaining aspect ratio
+            if self.image_size:
+                img.thumbnail((self.image_size, self.image_size))
+            return img
+        except Exception as e:
+            logger.warning(f"Failed to open screenshot: {e}")
+            return None
+
+    def _run_inference(
+        self,
+        messages: list[dict[str, Any]],
+        image: Any,
+    ) -> str:
+        """Run model inference."""
+        import torch
+
+        text = self._processor.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+
+        inputs = self._processor(
+            text=[text],
+            images=[image],
+            padding=True,
+            return_tensors="pt",
+        )
+
+        device = next(self._model.parameters()).device
+        inputs = inputs.to(device)
+
+        with torch.no_grad():
+            output_ids = self._model.generate(
+                **inputs,
+                max_new_tokens=self.max_new_tokens,
+            )
+
+        input_len = inputs["input_ids"].shape[1]
+        generated_ids = output_ids[:, input_len:]
+        response = self._processor.batch_decode(
+            generated_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]
+
+        return response.strip()
+
+    def set_demo(self, demo: str) -> None:
+        """Set or update the demonstration trajectory."""
+        self.demo = demo
+        logger.info(f"Demo set ({len(demo)} chars) - persists across all steps")

--- a/openadapt_evals/benchmarks/cli.py
+++ b/openadapt_evals/benchmarks/cli.py
@@ -213,9 +213,17 @@ def cmd_mock(args: argparse.Namespace) -> int:
         except RuntimeError as e:
             print(f"ERROR: {e}")
             return 1
+    elif agent_type == "smol":
+        try:
+            from openadapt_evals.agents import SmolOperatorAgent
+            agent = SmolOperatorAgent(demo=demo_text)
+            print(f"Using SmolOperatorAgent (model={agent.model_path}, demo={'yes' if agent.demo else 'no'})")
+        except RuntimeError as e:
+            print(f"ERROR: {e}")
+            return 1
     else:
         print(f"ERROR: Unknown agent type: {agent_type}")
-        print("Available for mock: mock, api-claude, api-openai, api-claude-cu, qwen3vl")
+        print("Available for mock: mock, api-claude, api-openai, api-claude-cu, qwen3vl, smol")
         return 1
 
     # Create config for trace collection
@@ -363,9 +371,17 @@ def cmd_run(args: argparse.Namespace) -> int:
         except RuntimeError as e:
             print(f"ERROR: {e}")
             return 1
+    elif agent_type == "smol":
+        try:
+            from openadapt_evals.agents import SmolOperatorAgent
+            agent = SmolOperatorAgent(demo=demo_text)
+            print(f"Using SmolOperatorAgent (model={agent.model_path}, demo={'yes' if agent.demo else 'no'})")
+        except RuntimeError as e:
+            print(f"ERROR: {e}")
+            return 1
     else:
         print(f"ERROR: Unknown agent type: {agent_type}")
-        print("Available: noop, mock, api-claude, api-openai, api-claude-cu, qwen3vl")
+        print("Available: noop, mock, api-claude, api-openai, api-claude-cu, qwen3vl, smol")
         return 1
 
     # Create config for trace collection
@@ -522,10 +538,18 @@ def cmd_live(args: argparse.Namespace) -> int:
         except RuntimeError as e:
             print(f"ERROR: {e}")
             return 1
+    elif agent_type == "smol":
+        try:
+            from openadapt_evals.agents import SmolOperatorAgent
+            agent = SmolOperatorAgent(demo=demo_text)
+            print(f"Using SmolOperatorAgent (model={agent.model_path}, demo={'yes' if agent.demo else 'no'})")
+        except RuntimeError as e:
+            print(f"ERROR: {e}")
+            return 1
     else:
         print(f"ERROR: Unknown agent type: {agent_type}")
         print(
-            "Available: mock, noop, api-claude, api-openai, api-claude-cu, qwen3vl, retrieval-claude, retrieval-openai"
+            "Available: mock, noop, api-claude, api-openai, api-claude-cu, qwen3vl, smol, retrieval-claude, retrieval-openai"
         )
         return 1
 
@@ -2087,6 +2111,9 @@ def cmd_eval_suite(args: argparse.Namespace) -> int:
                         model_path=model_path, model_endpoint=model_endpoint,
                         demo=demo_text, use_thinking=use_thinking,
                     )
+                elif args.agent == "smol":
+                    from openadapt_evals.agents import SmolOperatorAgent
+                    agent = SmolOperatorAgent(demo=demo_text)
                 else:
                     provider = _suite_agent_provider(args.agent)
                     agent = ApiAgent(provider=provider, demo=demo_text)
@@ -2147,7 +2174,7 @@ def main() -> int:
     mock_parser.add_argument("--tasks", type=int, default=10, help="Number of tasks")
     mock_parser.add_argument("--max-steps", type=int, default=15, help="Max steps per task")
     mock_parser.add_argument("--agent", type=str, default="mock",
-                            help="Agent type: mock, api-claude, api-openai, api-claude-cu, qwen3vl")
+                            help="Agent type: mock, api-claude, api-openai, api-claude-cu, qwen3vl, smol")
     mock_parser.add_argument("--demo", type=str, help="Demo trajectory file for ApiAgent")
     mock_parser.add_argument("--model-path", type=str, help="Model path for Qwen3VL agent")
     mock_parser.add_argument("--model-endpoint", type=str, help="Remote endpoint for Qwen3VL ('modal' or HTTP URL)")
@@ -2166,7 +2193,7 @@ def main() -> int:
     run_parser.add_argument("--evaluate-url", type=str, default="http://localhost:5050",
                            help="Evaluate server URL (default: localhost:5050)")
     run_parser.add_argument("--agent", type=str, default="api-openai",
-                           help="Agent type: noop, mock, api-claude, api-openai, api-claude-cu, qwen3vl")
+                           help="Agent type: noop, mock, api-claude, api-openai, api-claude-cu, qwen3vl, smol")
     run_parser.add_argument("--task", type=str,
                            help="Single task ID (e.g., notepad_1)")
     run_parser.add_argument("--tasks", type=str,
@@ -2191,7 +2218,7 @@ def main() -> int:
     live_parser.add_argument("--evaluate-url", type=str, default="http://localhost:5050",
                             help="Evaluate server URL (default: localhost:5050)")
     live_parser.add_argument("--agent", type=str, default="mock",
-                            help="Agent type: mock, noop, api-claude, api-openai, api-claude-cu, qwen3vl, retrieval-claude, retrieval-openai")
+                            help="Agent type: mock, noop, api-claude, api-openai, api-claude-cu, qwen3vl, smol, retrieval-claude, retrieval-openai")
     live_parser.add_argument("--demo", type=str, help="Demo trajectory file for ApiAgent")
     live_parser.add_argument("--model-path", type=str, help="Model path for Qwen3VL agent")
     live_parser.add_argument("--model-endpoint", type=str, help="Remote endpoint for Qwen3VL ('modal' or HTTP URL)")
@@ -2463,7 +2490,7 @@ def main() -> int:
     )
     suite_parser.add_argument(
         "--agent", type=str, default="api-openai",
-        help="Agent type: api-openai, api-claude, api-claude-cu, qwen3vl",
+        help="Agent type: api-openai, api-claude, api-claude-cu, qwen3vl, smol",
     )
     suite_parser.add_argument(
         "--model-path", type=str,

--- a/tests/test_smol_agent.py
+++ b/tests/test_smol_agent.py
@@ -1,0 +1,314 @@
+"""Tests for SmolOperatorAgent action parsing and agent behavior."""
+
+import pytest
+
+from openadapt_evals.agents.smol_agent import (
+    SmolOperatorAgent,
+    parse_smol_action,
+    _extract_action_string,
+)
+from openadapt_evals.adapters.base import BenchmarkAction, BenchmarkObservation
+
+
+# ---------------------------------------------------------------------------
+# Action string extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractActionString:
+    """Tests for _extract_action_string."""
+
+    def test_plain_action(self):
+        assert _extract_action_string("click(x=0.5, y=0.3)") == "click(x=0.5, y=0.3)"
+
+    def test_with_think_block(self):
+        resp = "<think>I see a button</think>\nclick(x=0.5, y=0.3)"
+        assert _extract_action_string(resp) == "click(x=0.5, y=0.3)"
+
+    def test_with_code_block(self):
+        resp = "<think>reasoning</think>\n<code>type(text='hello')</code>"
+        assert _extract_action_string(resp) == "type(text='hello')"
+
+    def test_empty_response(self):
+        assert _extract_action_string("") is None
+
+    def test_think_only(self):
+        assert _extract_action_string("<think>just thinking</think>") is None
+
+
+# ---------------------------------------------------------------------------
+# Click actions
+# ---------------------------------------------------------------------------
+
+
+class TestClickParsing:
+    """Tests for click action parsing."""
+
+    def test_click_basic(self):
+        action = parse_smol_action("click(x=0.5, y=0.3)")
+        assert action.type == "click"
+        assert action.x == pytest.approx(0.5)
+        assert action.y == pytest.approx(0.3)
+
+    def test_click_high_precision(self):
+        action = parse_smol_action("click(x=0.8875, y=0.2281)")
+        assert action.type == "click"
+        assert action.x == pytest.approx(0.8875)
+        assert action.y == pytest.approx(0.2281)
+
+    def test_double_click(self):
+        action = parse_smol_action("double_click(x=0.81, y=0.95)")
+        assert action.type == "click"
+        assert action.x == pytest.approx(0.81)
+        assert action.y == pytest.approx(0.95)
+        assert action.raw_action["click_variant"] == "double_click"
+
+    def test_long_press(self):
+        action = parse_smol_action("long_press(x=0.8, y=0.9)")
+        assert action.type == "click"
+        assert action.raw_action["click_variant"] == "long_press"
+
+    def test_click_not_confused_with_double(self):
+        """Ensure 'click' regex doesn't match inside 'double_click'."""
+        action = parse_smol_action("double_click(x=0.5, y=0.5)")
+        assert action.raw_action.get("click_variant") == "double_click"
+
+
+# ---------------------------------------------------------------------------
+# Type / Press actions
+# ---------------------------------------------------------------------------
+
+
+class TestTypeParsing:
+    """Tests for type and press action parsing."""
+
+    def test_type_single_quotes(self):
+        action = parse_smol_action("type(text='hello world')")
+        assert action.type == "type"
+        assert action.text == "hello world"
+
+    def test_type_double_quotes(self):
+        action = parse_smol_action('type(text="bread buns")')
+        assert action.type == "type"
+        assert action.text == "bread buns"
+
+    def test_press_single_key(self):
+        action = parse_smol_action("press(keys=['enter'])")
+        assert action.type == "key"
+        assert action.key == "enter"
+        assert action.modifiers is None
+
+    def test_press_modifier_combo(self):
+        action = parse_smol_action("press(keys=['ctrl', 'c'])")
+        assert action.type == "key"
+        assert action.key == "c"
+        assert action.modifiers == ["ctrl"]
+
+    def test_press_three_keys(self):
+        action = parse_smol_action("press(keys=['ctrl', 'shift', 'n'])")
+        assert action.type == "key"
+        assert action.key == "n"
+        assert action.modifiers == ["ctrl", "shift"]
+
+
+# ---------------------------------------------------------------------------
+# Scroll / Drag / Swipe
+# ---------------------------------------------------------------------------
+
+
+class TestScrollDragSwipe:
+    """Tests for scroll, drag, and swipe parsing."""
+
+    def test_scroll_up(self):
+        action = parse_smol_action("scroll(direction='up', amount=10)")
+        assert action.type == "scroll"
+        assert action.scroll_direction == "up"
+        assert action.scroll_amount == 10.0
+
+    def test_scroll_default_amount(self):
+        action = parse_smol_action("scroll(direction='down')")
+        assert action.type == "scroll"
+        assert action.scroll_direction == "down"
+        assert action.scroll_amount == 3.0
+
+    def test_drag(self):
+        action = parse_smol_action(
+            "drag(from_coord=[0.1, 0.2], to_coord=[0.8, 0.5])"
+        )
+        assert action.type == "drag"
+        assert action.x == pytest.approx(0.1)
+        assert action.y == pytest.approx(0.2)
+        assert action.end_x == pytest.approx(0.8)
+        assert action.end_y == pytest.approx(0.5)
+
+    def test_swipe_maps_to_drag(self):
+        action = parse_smol_action(
+            "swipe(from_coord=[0.581, 0.898], to_coord=[0.601, 0.518])"
+        )
+        assert action.type == "drag"
+        assert action.x == pytest.approx(0.581)
+        assert action.raw_action.get("action_variant") == "swipe"
+
+
+# ---------------------------------------------------------------------------
+# Special actions
+# ---------------------------------------------------------------------------
+
+
+class TestSpecialActions:
+    """Tests for final_answer, navigate_home, open_app."""
+
+    def test_final_answer(self):
+        action = parse_smol_action("final_answer('success')")
+        assert action.type == "done"
+        assert action.answer == "success"
+
+    def test_navigate_home(self):
+        action = parse_smol_action("navigate_home()")
+        assert action.type == "key"
+        assert action.key == "super"
+
+    def test_open_app(self):
+        action = parse_smol_action("open_app(app_name='notepad')")
+        assert action.type == "type"
+        assert action.text == "notepad"
+
+    def test_unknown_action(self):
+        action = parse_smol_action("some_unknown_action()")
+        assert action.type == "done"
+        assert "parse_error" in action.raw_action
+
+    def test_empty_response(self):
+        action = parse_smol_action("")
+        assert action.type == "done"
+        assert "parse_error" in action.raw_action
+
+
+# ---------------------------------------------------------------------------
+# Think/Code block handling
+# ---------------------------------------------------------------------------
+
+
+class TestThinkCodeBlocks:
+    """Tests for <think>/<code> block parsing."""
+
+    def test_think_then_action(self):
+        resp = "<think>I need to click the submit button</think>\nclick(x=0.5, y=0.3)"
+        action = parse_smol_action(resp)
+        assert action.type == "click"
+        assert action.raw_action.get("thinking") == "I need to click the submit button"
+
+    def test_code_block(self):
+        resp = "<think>reasoning</think>\n<code>type(text='hello')</code>"
+        action = parse_smol_action(resp)
+        assert action.type == "type"
+        assert action.text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Coordinates are [0, 1] — no conversion needed
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinateRange:
+    """Verify coordinates pass through as-is (already [0, 1])."""
+
+    def test_coordinates_preserved(self):
+        action = parse_smol_action("click(x=0.8875, y=0.2281)")
+        assert action.x == pytest.approx(0.8875)
+        assert action.y == pytest.approx(0.2281)
+
+    def test_viewport_stored_in_raw(self):
+        action = parse_smol_action(
+            "click(x=0.5, y=0.5)", viewport=(1920, 1080)
+        )
+        assert action.raw_action["viewport"] == (1920, 1080)
+
+
+# ---------------------------------------------------------------------------
+# Agent behavior
+# ---------------------------------------------------------------------------
+
+
+class TestSmolOperatorAgent:
+    """Tests for SmolOperatorAgent."""
+
+    def test_init_defaults(self):
+        agent = SmolOperatorAgent()
+        assert agent.model_path == "smolagents/SmolVLM2-2.2B-Instruct-Agentic-GUI"
+        assert agent.demo is None
+        assert agent._step_count == 0
+
+    def test_init_with_demo(self):
+        agent = SmolOperatorAgent(demo="Step 0: click(x=0.5, y=0.5)")
+        assert agent.demo is not None
+
+    def test_reset(self):
+        agent = SmolOperatorAgent()
+        agent._step_count = 5
+        agent._previous_actions = ["click(x=0.1, y=0.2)", "type(text='hello')"]
+        agent.reset()
+        assert agent._step_count == 0
+        assert agent._previous_actions == []
+
+    def test_set_demo(self):
+        agent = SmolOperatorAgent()
+        assert agent.demo is None
+        agent.set_demo("Step 0: click(x=0.5, y=0.5)")
+        assert agent.demo is not None
+
+    def test_build_prompt_basic(self):
+        agent = SmolOperatorAgent()
+        prompt = agent._build_prompt("Open Notepad")
+        assert "Instruction: Open Notepad" in prompt
+        assert "Output exactly one action." in prompt
+
+    def test_build_prompt_with_demo(self):
+        agent = SmolOperatorAgent(demo="Step 0: click(x=0.1, y=0.9)")
+        prompt = agent._build_prompt("Open Notepad")
+        assert "Demonstration" in prompt
+        assert "Step 0: click(x=0.1, y=0.9)" in prompt
+
+    def test_build_prompt_with_history(self):
+        agent = SmolOperatorAgent()
+        agent._previous_actions = ["click(x=0.1, y=0.2)", "type(text='hi')"]
+        prompt = agent._build_prompt("Open Notepad")
+        assert "Previous actions:" in prompt
+        assert "Step 0: click(x=0.1, y=0.2)" in prompt
+        assert "Step 1: type(text='hi')" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Mock adapter integration
+# ---------------------------------------------------------------------------
+
+
+class TestMockAdapterIntegration:
+    """Test SmolOperatorAgent actions work with mock adapter."""
+
+    def test_click_action_accepted_by_mock(self):
+        """Verify parsed click produces valid BenchmarkAction for mock adapter."""
+        action = parse_smol_action("click(x=0.5, y=0.5)")
+        assert action.type == "click"
+        assert 0 <= action.x <= 1
+        assert 0 <= action.y <= 1
+
+        from openadapt_evals.adapters.waa.mock import WAAMockAdapter
+
+        adapter = WAAMockAdapter(num_tasks=1, domains=["notepad"])
+        task = adapter.list_tasks()[0]
+        adapter.reset(task)
+        obs, done, info = adapter.step(action)
+        assert not done
+
+    def test_done_action_ends_episode(self):
+        action = parse_smol_action("final_answer('done')")
+        assert action.type == "done"
+
+        from openadapt_evals.adapters.waa.mock import WAAMockAdapter
+
+        adapter = WAAMockAdapter(num_tasks=1, domains=["notepad"])
+        task = adapter.list_tasks()[0]
+        adapter.reset(task)
+        obs, done, info = adapter.step(action)
+        assert done


### PR DESCRIPTION
## Summary
- Adds `SmolOperatorAgent` wrapping the pre-trained `smolagents/SmolVLM2-2.2B-Instruct-Agentic-GUI` model as a `BenchmarkAgent` for GUI automation evaluation
- Coordinates are natively in [0,1] range — no pixel-to-normalized conversion needed. Supports click, double_click, long_press, type, press, scroll, drag, swipe, and final_answer actions
- Registered in CLI as `smol` agent type across mock, run, live, and eval-suite commands
- 37 dedicated unit tests covering action parsing, coordinate handling, error paths, and mock adapter integration

## Test plan
- [ ] 37 unit tests in `tests/test_smol_agent.py` pass (`uv run pytest tests/test_smol_agent.py -v`)
- [ ] Mock adapter integration verified end-to-end
- [ ] Full test suite (406 tests) passes with no regressions (`uv run pytest tests/ -v`)
- [ ] CLI help text updated to include `smol` in all relevant subcommands

🤖 Generated with [Claude Code](https://claude.com/claude-code)