### PR TITLE
fix: resolve element grounding for AT-SPI a11y tree format

### DIFF
--- a/openadapt_evals/benchmarks/cli.py
+++ b/openadapt_evals/benchmarks/cli.py
@@ -280,6 +280,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     server_url = args.server
     evaluate_url = getattr(args, "evaluate_url", None)
+    waa_examples_path = getattr(args, "waa_examples_path", None)
     print(f"Connecting to WAA server at {server_url}...")
 
     # Create live adapter
@@ -287,6 +288,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         server_url=server_url,
         evaluate_url=evaluate_url,
         max_steps=args.max_steps,
+        waa_examples_path=waa_examples_path,
     )
     adapter = WAALiveAdapter(config)
 
@@ -2228,6 +2230,8 @@ def main() -> int:
                             help="Path to demo library for retrieval agents")
     live_parser.add_argument("--task-ids", type=str, help="Comma-separated task IDs")
     live_parser.add_argument("--max-steps", type=int, default=15, help="Max steps per task")
+    live_parser.add_argument("--waa-examples-path", type=str,
+                            help="Path to WAA evaluation_examples_windows directory for task configs")
     live_parser.add_argument("--output", type=str, help="Output directory for traces")
     live_parser.add_argument("--run-name", type=str, help="Name for this evaluation run")
 


### PR DESCRIPTION
## Summary
- Fix XML parser to handle AT-SPI format a11y trees (lowercase `name`, namespaced `cp:screencoord`/`cp:size`)
- Use element name as fallback ID when AutomationId is absent — enables Claude's `click_element("Start")` to resolve
- Add recursive glob fallback for UUID task IDs in `_load_task_from_disk`
- Add `--waa-examples-path` CLI arg for local task config loading
- Fix `waa_server_patch.py` evaluator paths (`/client/desktop_env`) and default port (5050)

## Context
With a11y tree grounding (PR #47), Claude correctly outputs `click_element("Start")` / `click_element("Save")` etc. by reading element names from the XML tree. However, the adapter's rect lookup was empty because the XML parser didn't handle the AT-SPI namespace format — so all element lookups fell back to pixel coordinates.

After this fix, element grounding works end-to-end on live WAA. In testing, Claude completed an 8-step Notepad task using element-based actions for "Notepad" and "Save" buttons.

## Test plan
- [x] 400 tests pass (including 2 new AT-SPI format tests)
- [x] Live WAA eval: Claude uses `click_element("Start")`, `click_element("Notepad")`, `click_element("Save")` — all resolve to correct coordinates
- [x] No "Element ID not found in rects" warnings with fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)