### PR TITLE
fix: add build-time and runtime validation for evaluate_server.py deployment

### DIFF
--- a/openadapt_evals/infrastructure/pool.py
+++ b/openadapt_evals/infrastructure/pool.py
@@ -208,9 +208,8 @@ docker run -d --name winarena \\
   -e CPU_CORES=4 \\
   -e DISK_SIZE=64G \\
   -e ARGUMENTS="-qmp tcp:0.0.0.0:7200,server,nowait" \\
-  --entrypoint /bin/bash \\
   waa-auto:latest \\
-  -c 'cd /client && python /evaluate_server.py > /tmp/evaluate_server.log 2>&1 & /entry.sh --prepare-image false --start-client false'
+  /entry.sh --prepare-image false --start-client false
 
 # Start the socat proxy via systemd (installed during Docker setup).
 # The systemd service auto-restarts on failure and survives reboots.
@@ -382,19 +381,24 @@ class PoolManager:
                         ["ssh", *SSH_OPTS, f"azureuser@{ip}", "mkdir -p /tmp/waa-build"],
                         capture_output=True,
                     )
-                    for fname in [
+                    required_files = [
                         "Dockerfile",
                         "evaluate_server.py",
                         "start_with_evaluate.sh",
                         "start_waa_server.bat",
                         "api_agent.py",
-                    ]:
+                    ]
+                    for fname in required_files:
                         src = waa_deploy_dir / fname
-                        if src.exists():
-                            subprocess.run(
-                                ["scp", *SSH_OPTS, str(src), f"azureuser@{ip}:/tmp/waa-build/"],
-                                capture_output=True,
-                            )
+                        if not src.exists():
+                            return (name, False, f"Missing build file: {fname}")
+                        scp_result = subprocess.run(
+                            ["scp", *SSH_OPTS, str(src), f"azureuser@{ip}:/tmp/waa-build/"],
+                            capture_output=True,
+                            text=True,
+                        )
+                        if scp_result.returncode != 0:
+                            return (name, False, f"SCP failed for {fname}: {scp_result.stderr[:100]}")
                 result = ssh_run(ip, docker_script, stream=False, step="DOCKER")
                 error = result.stderr[:200] if result.stderr else ""
                 return (name, result.returncode == 0, error)

--- a/openadapt_evals/waa_deploy/Dockerfile
+++ b/openadapt_evals/waa_deploy/Dockerfile
@@ -151,6 +151,27 @@ COPY api_agent.py /client/mm_agents/api_agent.py
 
 COPY evaluate_server.py /evaluate_server.py
 
+# Verify evaluate_server.py was copied correctly (not a symlink or empty file).
+# A symlink to /proc/self/fd/0 has been observed when the build context is
+# missing the file or Docker copies from stdin.  Catch this at build time.
+RUN set -e && \
+    if [ -L /evaluate_server.py ]; then \
+        echo "FATAL: /evaluate_server.py is a symlink ($(readlink /evaluate_server.py)), not a regular file." >&2; \
+        echo "This means the Docker build context was missing evaluate_server.py." >&2; \
+        exit 1; \
+    fi && \
+    if [ ! -s /evaluate_server.py ]; then \
+        echo "FATAL: /evaluate_server.py is empty or missing." >&2; \
+        exit 1; \
+    fi && \
+    for route in '/probe' '/task/' '/setup' '/evaluate'; do \
+        if ! grep -q "$route" /evaluate_server.py; then \
+            echo "FATAL: /evaluate_server.py missing expected route: $route" >&2; \
+            exit 1; \
+        fi; \
+    done && \
+    echo "evaluate_server.py verified: $(wc -l < /evaluate_server.py) lines, all routes present"
+
 # Install flask for the evaluate server and socat for port forwarding
 RUN pip install flask requests-toolbelt 2>/dev/null || pip3 install flask requests-toolbelt 2>/dev/null || \
     python -m pip install flask requests-toolbelt 2>/dev/null || \

--- a/openadapt_evals/waa_deploy/start_with_evaluate.sh
+++ b/openadapt_evals/waa_deploy/start_with_evaluate.sh
@@ -2,9 +2,29 @@
 # Start the evaluate server in background (runs on Docker Linux side)
 # The evaluate server provides /evaluate and /task/<id> endpoints using
 # WAA's evaluator modules from /client/desktop_env/evaluators/
-cd /client
-python /evaluate_server.py > /tmp/evaluate_server.log 2>&1 &
-echo "Evaluate server started on port 5050 (PID: $!)"
+
+EVAL_SERVER="/evaluate_server.py"
+
+# Validate evaluate_server.py before starting
+if [ -L "$EVAL_SERVER" ]; then
+    echo "ERROR: $EVAL_SERVER is a symlink to $(readlink "$EVAL_SERVER"), not a real file." >&2
+    echo "The Docker image was built incorrectly. Rebuild with evaluate_server.py in the build context." >&2
+elif [ ! -f "$EVAL_SERVER" ]; then
+    echo "ERROR: $EVAL_SERVER does not exist." >&2
+    echo "The Docker image is missing the evaluate server. Rebuild the image." >&2
+elif [ ! -s "$EVAL_SERVER" ]; then
+    echo "ERROR: $EVAL_SERVER is empty (0 bytes)." >&2
+    echo "The Docker image was built with a corrupt evaluate_server.py. Rebuild the image." >&2
+elif ! grep -q '/probe' "$EVAL_SERVER" || ! grep -q '/evaluate' "$EVAL_SERVER"; then
+    echo "ERROR: $EVAL_SERVER is missing expected Flask routes (/probe, /evaluate)." >&2
+    echo "File content (first 5 lines):" >&2
+    head -5 "$EVAL_SERVER" >&2
+    echo "The file may be corrupt. Rebuild the image." >&2
+else
+    cd /client
+    python "$EVAL_SERVER" > /tmp/evaluate_server.log 2>&1 &
+    echo "Evaluate server started on port 5050 (PID: $!)"
+fi
 
 # Execute the command passed as arguments (e.g., /entry.sh --prepare-image false)
 exec "$@"

--- a/tests/test_evaluate_server_deploy.py
+++ b/tests/test_evaluate_server_deploy.py
@@ -1,0 +1,298 @@
+"""Tests for evaluate_server.py deployment integrity.
+
+Validates that the evaluate_server.py source file and Dockerfile are
+correctly configured to avoid the symlink-to-stdin bug where
+/evaluate_server.py in the container becomes a symlink to /proc/self/fd/0
+instead of a real file.
+"""
+
+import os
+import re
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Path to the waa_deploy directory (source files for Docker build context)
+WAA_DEPLOY_DIR = Path(__file__).resolve().parents[1] / "openadapt_evals" / "waa_deploy"
+EVALUATE_SERVER_PATH = WAA_DEPLOY_DIR / "evaluate_server.py"
+DOCKERFILE_PATH = WAA_DEPLOY_DIR / "Dockerfile"
+ENTRYPOINT_SCRIPT_PATH = WAA_DEPLOY_DIR / "start_with_evaluate.sh"
+
+
+class TestEvaluateServerSourceFile:
+    """Validate the evaluate_server.py source file exists and has expected content."""
+
+    def test_file_exists(self):
+        """evaluate_server.py must exist in the waa_deploy directory."""
+        assert EVALUATE_SERVER_PATH.exists(), (
+            f"evaluate_server.py not found at {EVALUATE_SERVER_PATH}. "
+            "This file is required for the Docker build context."
+        )
+
+    def test_file_is_not_empty(self):
+        """evaluate_server.py must have content (not be a 0-byte file)."""
+        assert EVALUATE_SERVER_PATH.stat().st_size > 0, (
+            "evaluate_server.py is empty (0 bytes). Expected a Python Flask server."
+        )
+
+    def test_file_is_not_symlink(self):
+        """evaluate_server.py must be a regular file, not a symlink."""
+        assert not EVALUATE_SERVER_PATH.is_symlink(), (
+            f"evaluate_server.py is a symlink to {os.readlink(EVALUATE_SERVER_PATH)}. "
+            "This was the root cause of the deployment bug."
+        )
+
+    def test_minimum_size(self):
+        """evaluate_server.py should be a substantial file (not a stub)."""
+        size = EVALUATE_SERVER_PATH.stat().st_size
+        assert size > 1000, (
+            f"evaluate_server.py is only {size} bytes. "
+            "Expected a full Flask server (typically 20KB+)."
+        )
+
+    def test_has_probe_route(self):
+        """evaluate_server.py must define the /probe health check route."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "'/probe'" in content or '"/probe"' in content, (
+            "evaluate_server.py is missing the /probe route. "
+            "This is the health check endpoint."
+        )
+
+    def test_has_task_route(self):
+        """evaluate_server.py must define the /task/<task_id> route."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "/task/" in content, (
+            "evaluate_server.py is missing the /task/ route. "
+            "This serves task configurations."
+        )
+
+    def test_has_setup_route(self):
+        """evaluate_server.py must define the /setup route."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "'/setup'" in content or '"/setup"' in content, (
+            "evaluate_server.py is missing the /setup route. "
+            "This handles task setup."
+        )
+
+    def test_has_evaluate_route(self):
+        """evaluate_server.py must define the /evaluate route."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "'/evaluate'" in content or '"/evaluate"' in content, (
+            "evaluate_server.py is missing the /evaluate route. "
+            "This is the core evaluation endpoint."
+        )
+
+    def test_has_flask_app(self):
+        """evaluate_server.py must create a Flask application."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "Flask(__name__)" in content, (
+            "evaluate_server.py is missing Flask(__name__) app creation."
+        )
+
+    def test_listens_on_port_5050(self):
+        """evaluate_server.py must listen on port 5050."""
+        content = EVALUATE_SERVER_PATH.read_text()
+        assert "5050" in content, (
+            "evaluate_server.py does not reference port 5050. "
+            "The evaluate server must listen on port 5050."
+        )
+
+
+class TestDockerfileCopyIntegrity:
+    """Validate the Dockerfile correctly copies and verifies evaluate_server.py."""
+
+    def test_dockerfile_exists(self):
+        """Dockerfile must exist in waa_deploy directory."""
+        assert DOCKERFILE_PATH.exists(), (
+            f"Dockerfile not found at {DOCKERFILE_PATH}"
+        )
+
+    def test_dockerfile_copies_evaluate_server(self):
+        """Dockerfile must COPY evaluate_server.py."""
+        content = DOCKERFILE_PATH.read_text()
+        assert "COPY evaluate_server.py /evaluate_server.py" in content, (
+            "Dockerfile missing 'COPY evaluate_server.py /evaluate_server.py'. "
+            "The evaluate server must be copied into the image."
+        )
+
+    def test_dockerfile_does_not_copy_from_stdin(self):
+        """Dockerfile must not use stdin COPY syntax (COPY - /path)."""
+        content = DOCKERFILE_PATH.read_text()
+        # Match 'COPY - /...' or 'COPY - /...' patterns (stdin copy)
+        stdin_copies = re.findall(r'COPY\s+- \s*/\S+', content)
+        assert not stdin_copies, (
+            f"Dockerfile uses stdin COPY syntax which can create symlinks "
+            f"to /proc/self/fd/0: {stdin_copies}"
+        )
+
+    def test_dockerfile_has_verification_step(self):
+        """Dockerfile must verify evaluate_server.py after COPY."""
+        content = DOCKERFILE_PATH.read_text()
+        # Look for the verification RUN that checks for symlinks
+        assert "-L /evaluate_server.py" in content, (
+            "Dockerfile is missing the post-COPY symlink verification step. "
+            "Add a RUN that checks /evaluate_server.py is not a symlink."
+        )
+
+    def test_dockerfile_verifies_routes(self):
+        """Dockerfile verification must check for expected routes."""
+        content = DOCKERFILE_PATH.read_text()
+        assert "/probe" in content and "/evaluate" in content, (
+            "Dockerfile verification should check for expected Flask routes."
+        )
+
+
+class TestEntrypointScript:
+    """Validate the entrypoint script validates evaluate_server.py at startup."""
+
+    def test_entrypoint_exists(self):
+        """start_with_evaluate.sh must exist."""
+        assert ENTRYPOINT_SCRIPT_PATH.exists(), (
+            f"start_with_evaluate.sh not found at {ENTRYPOINT_SCRIPT_PATH}"
+        )
+
+    def test_entrypoint_checks_symlink(self):
+        """Entrypoint must check if evaluate_server.py is a symlink."""
+        content = ENTRYPOINT_SCRIPT_PATH.read_text()
+        assert "-L" in content, (
+            "start_with_evaluate.sh does not check for symlinks. "
+            "It must validate /evaluate_server.py is not a symlink before running it."
+        )
+
+    def test_entrypoint_checks_empty_file(self):
+        """Entrypoint must check if evaluate_server.py is empty."""
+        content = ENTRYPOINT_SCRIPT_PATH.read_text()
+        assert "-s" in content, (
+            "start_with_evaluate.sh does not check for empty files. "
+            "It must validate /evaluate_server.py has content before running it."
+        )
+
+    def test_entrypoint_checks_routes(self):
+        """Entrypoint must check for expected routes."""
+        content = ENTRYPOINT_SCRIPT_PATH.read_text()
+        assert "/probe" in content or "/evaluate" in content, (
+            "start_with_evaluate.sh does not verify Flask routes. "
+            "It should check that the file contains expected route definitions."
+        )
+
+    def test_entrypoint_exec_passthrough(self):
+        """Entrypoint must exec $@ to pass through to the main process."""
+        content = ENTRYPOINT_SCRIPT_PATH.read_text()
+        assert 'exec "$@"' in content, (
+            "start_with_evaluate.sh missing 'exec \"$@\"'. "
+            "It must pass through to the main entry point."
+        )
+
+
+class TestPoolManagerEntrypoint:
+    """Validate pool.py WAA_START_SCRIPT uses the Dockerfile entrypoint."""
+
+    def test_waa_start_script_no_entrypoint_override(self):
+        """WAA_START_SCRIPT must not override --entrypoint to /bin/bash."""
+        from openadapt_evals.infrastructure.pool import WAA_START_SCRIPT
+
+        assert "--entrypoint /bin/bash" not in WAA_START_SCRIPT, (
+            "WAA_START_SCRIPT overrides --entrypoint to /bin/bash, bypassing "
+            "start_with_evaluate.sh and its validation. Remove --entrypoint to "
+            "use the Dockerfile's ENTRYPOINT which includes startup checks."
+        )
+
+    def test_waa_start_script_uses_entry_sh(self):
+        """WAA_START_SCRIPT must pass /entry.sh as command (not inline python)."""
+        from openadapt_evals.infrastructure.pool import WAA_START_SCRIPT
+
+        assert "/entry.sh" in WAA_START_SCRIPT, (
+            "WAA_START_SCRIPT does not reference /entry.sh. "
+            "The container should run /entry.sh via the Dockerfile entrypoint."
+        )
+
+
+class TestDockerBuildContextFiles:
+    """Validate all files needed for Docker build context exist."""
+
+    REQUIRED_FILES = [
+        "Dockerfile",
+        "evaluate_server.py",
+        "start_with_evaluate.sh",
+        "start_waa_server.bat",
+        "api_agent.py",
+    ]
+
+    def test_all_build_context_files_exist(self):
+        """All files referenced in pool.py setup_docker must exist."""
+        missing = []
+        for fname in self.REQUIRED_FILES:
+            path = WAA_DEPLOY_DIR / fname
+            if not path.exists():
+                missing.append(fname)
+        assert not missing, (
+            f"Missing Docker build context files: {missing}. "
+            "These files are SCP'd to the VM during pool-create."
+        )
+
+    def test_all_build_context_files_nonempty(self):
+        """All Docker build context files must have content."""
+        empty = []
+        for fname in self.REQUIRED_FILES:
+            path = WAA_DEPLOY_DIR / fname
+            if path.exists() and path.stat().st_size == 0:
+                empty.append(fname)
+        assert not empty, (
+            f"Empty Docker build context files: {empty}. "
+            "These files must have content for the Docker build to succeed."
+        )
+
+
+class TestEvaluateServerImport:
+    """Test that evaluate_server.py can be imported (with mocked WAA internals)."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_waa_internals(self):
+        """Stub WAA container modules so evaluate_server can be imported."""
+        mock_modules = [
+            "controllers",
+            "controllers.python",
+            "evaluators",
+            "evaluators.getters",
+            "evaluators.metrics",
+        ]
+        stubs = {}
+        for mod_name in mock_modules:
+            if mod_name not in sys.modules:
+                stubs[mod_name] = types.ModuleType(mod_name)
+                sys.modules[mod_name] = stubs[mod_name]
+
+        pc_mock = MagicMock(name="PythonController")
+        sys.modules["controllers.python"].PythonController = pc_mock
+
+        yield
+
+        for mod_name in stubs:
+            sys.modules.pop(mod_name, None)
+        sys.modules.pop("openadapt_evals.waa_deploy.evaluate_server", None)
+
+    def test_flask_app_has_expected_routes(self):
+        """Flask app must register all expected routes."""
+        from openadapt_evals.waa_deploy.evaluate_server import app
+
+        rules = [rule.rule for rule in app.url_map.iter_rules()]
+        assert "/probe" in rules, "Missing /probe route"
+        assert "/setup" in rules, "Missing /setup route"
+        assert "/evaluate" in rules, "Missing /evaluate route"
+        # /task/<task_id> shows as /task/<task_id> in url_map
+        task_routes = [r for r in rules if r.startswith("/task/")]
+        assert task_routes, "Missing /task/<task_id> route"
+
+    def test_flask_app_probe_returns_ok(self):
+        """The /probe endpoint must return status ok."""
+        from openadapt_evals.waa_deploy.evaluate_server import app
+
+        client = app.test_client()
+        resp = client.get("/probe")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"


### PR DESCRIPTION
## Summary

- **Dockerfile**: Add a `RUN` verification step after `COPY evaluate_server.py` that fails the Docker build if the file is a symlink (to `/proc/self/fd/0`), empty, or missing expected Flask routes (`/probe`, `/task/`, `/setup`, `/evaluate`)
- **start_with_evaluate.sh**: Add startup validation that checks `/evaluate_server.py` is a regular file with content and expected routes before starting it, with clear error messages for each failure mode
- **pool.py**: Remove `--entrypoint /bin/bash` override from `WAA_START_SCRIPT` so the container uses the Dockerfile `ENTRYPOINT` (`start_with_evaluate.sh`) which validates the file; add error checking for SCP file uploads during Docker build context transfer
- **tests**: Add 26 deployment integrity tests covering source file validation, Dockerfile correctness, entrypoint script validation, pool manager configuration, and Flask route registration

## Context

The evaluate server inside the Docker container was found to be a symlink to `/proc/self/fd/0` (stdin) instead of the actual 744-line Flask server. This caused the evaluate server to start with 0 registered routes, silently breaking all `/evaluate`, `/setup`, `/task/`, and `/probe` endpoints.

The `WAA_START_SCRIPT` in pool.py was overriding `--entrypoint /bin/bash` which bypassed `start_with_evaluate.sh` entirely, so any validation in the entrypoint was ineffective. Additionally, SCP failures during build context upload were silently ignored (`capture_output=True` with no returncode check), which could leave the build context incomplete.

## Test plan

- [x] All 26 new tests pass (`uv run pytest tests/test_evaluate_server_deploy.py -v`)
- [x] Full test suite passes (480/487 pass; 7 pre-existing failures in `test_synthetic_demos.py` due to missing demo files)
- [ ] Verify Docker build still succeeds on Azure VM (next pool-create)
- [ ] Verify evaluate server starts correctly with new entrypoint flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)