### PR TITLE
fix: remove bash syntax error in socat nohup fallback

### DIFF
--- a/scripts/record_waa_demos.py
+++ b/scripts/record_waa_demos.py
@@ -1343,7 +1343,7 @@ def _auto_start_socat(vm_ip: str) -> bool:
         "  || sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq socat; "
         "  nohup socat TCP-LISTEN:5051,fork,reuseaddr "
         "  'EXEC:docker exec -i winarena socat - TCP\\:127.0.0.1\\:5050' "
-        "  </dev/null >/dev/null 2>&1 &; "
+        "  </dev/null >/dev/null 2>&1 & "
         "fi"
     )
     result = subprocess.run(

--- a/scripts/run_dc_eval.py
+++ b/scripts/run_dc_eval.py
@@ -88,7 +88,7 @@ def _setup_eval_proxy(vm_user: str, vm_ip: str) -> bool:
         "  || sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq socat; "
         "  nohup socat TCP-LISTEN:5051,fork,reuseaddr "
         "  'EXEC:docker exec -i winarena socat - TCP\\:127.0.0.1\\:5050' "
-        "  </dev/null >/dev/null 2>&1 &; "
+        "  </dev/null >/dev/null 2>&1 & "
         "fi"
     )
     result = subprocess.run(


### PR DESCRIPTION
## Summary
- `&;` is a bash syntax error — `&` already terminates the command, so the trailing `;` causes a parse error
- This broke the socat nohup fallback path on older VMs that don't have the `socat-waa-evaluate` systemd service
- Fixed in both `run_dc_eval.py` and `record_waa_demos.py`

## Context
The bug was introduced when the systemd-first pattern was added (PR #62 for `record_waa_demos.py`, and earlier for `run_dc_eval.py`). The `if/else` block works fine on the systemd path; only the nohup fallback was broken.

## Test plan
- [ ] Deploy to a VM without the systemd service and verify socat starts via nohup

🤖 Generated with [Claude Code](https://claude.com/claude-code)