### PR TITLE
fix: unify fuzzy_match metrics into shared module

### DIFF
--- a/openadapt_evals/evaluation/client.py
+++ b/openadapt_evals/evaluation/client.py
@@ -3,23 +3,8 @@
 Runs WAA evaluators locally, making HTTP calls to the WAA server's /execute endpoint.
 This approach follows WAA's own design pattern and eliminates the need for a sidecar service.
 
-NOTE: Eval path divergence (see docs/designs/01-code-health-architecture.md, Issue 3)
-------
-This module's ``_fallback_metric("fuzzy_match", ...)`` (word-set overlap) diverges from
-``server/evaluate_endpoint.py`` ``StandaloneMetrics.fuzzy_match`` (rapidfuzz character-level
-Levenshtein ratio with 0.8 threshold fallback).  Specifically:
-
-  - evaluate_endpoint.py: uses ``rapidfuzz.fuzz.ratio`` (char-level edit distance),
-    returns 1.0 if score >= threshold else the raw ratio.  Falls back to substring
-    containment returning 0.8 when rapidfuzz is unavailable.
-
-  - This file (_fallback_metric): uses word-set intersection ratio
-    ``len(actual_words & expected_words) / len(expected_words)``.  No external dependency,
-    no threshold, purely token-level.
-
-These two implementations can give materially different scores for the same (actual, expected)
-pair.  The planned fix is to unify both behind a shared ``evaluation/core.py`` module
-(design doc Issue 3).  Do NOT add new metric logic here until that refactor lands.
+Fallback metrics are provided by ``evaluation.metrics`` (shared with
+``server/evaluate_endpoint.py``).
 """
 
 import sys
@@ -286,32 +271,13 @@ class EvaluatorClient:
         return self._fallback_metric(func_name, actual, expected)
 
     def _fallback_metric(self, func_name: str, actual: Any, expected: Any) -> float:
-        """Fallback metric implementations."""
-        if func_name == "exact_match":
-            return 1.0 if actual == expected else 0.0
+        """Fallback metric — delegates to shared evaluation.metrics module."""
+        from openadapt_evals.evaluation.metrics import get_metric, exact_match
 
-        elif func_name == "contains":
-            if isinstance(actual, str) and isinstance(expected, str):
-                return 1.0 if expected.lower() in actual.lower() else 0.0
-            return 0.0
-
-        elif func_name == "fuzzy_match":
-            if isinstance(actual, str) and isinstance(expected, str):
-                # Simple fuzzy: check if most words match
-                actual_words = set(actual.lower().split())
-                expected_words = set(expected.lower().split())
-                if not expected_words:
-                    return 0.0
-                overlap = len(actual_words & expected_words)
-                return overlap / len(expected_words)
-            return 0.0
-
-        elif func_name == "boolean":
-            return 1.0 if bool(actual) == bool(expected) else 0.0
-
-        else:
-            # Unknown metric, default to exact match
-            return 1.0 if actual == expected else 0.0
+        metric_fn = get_metric(func_name)
+        if metric_fn is not None:
+            return float(metric_fn(actual, expected))
+        return float(exact_match(actual, expected))
 
     def health_check(self) -> bool:
         """Check if WAA server is reachable."""

--- a/openadapt_evals/evaluation/metrics.py
+++ b/openadapt_evals/evaluation/metrics.py
@@ -1,0 +1,74 @@
+"""Shared metric implementations for evaluation.
+
+Single source of truth for metric functions used by both the client-side
+evaluator (evaluation/client.py) and the server-side evaluate endpoint
+(server/evaluate_endpoint.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def exact_match(result: Any, expected: Any, **options) -> float:
+    """Exact string/value match."""
+    if result == expected:
+        return 1.0
+    if str(result).strip() == str(expected).strip():
+        return 1.0
+    return 0.0
+
+
+def fuzzy_match(
+    result: Any, expected: Any, threshold: float = 0.8, **options
+) -> float:
+    """Fuzzy string matching using rapidfuzz (character-level Levenshtein).
+
+    Falls back to substring containment when rapidfuzz is not installed.
+    """
+    try:
+        from rapidfuzz import fuzz
+
+        score = fuzz.ratio(str(result), str(expected)) / 100.0
+        return 1.0 if score >= threshold else score
+    except ImportError:
+        result_str = str(result).lower()
+        expected_str = str(expected).lower()
+        if expected_str in result_str or result_str in expected_str:
+            return 0.8
+        return 0.0
+
+
+def contains(result: Any, expected: Any, **options) -> float:
+    """Check if result contains expected (case-insensitive)."""
+    result_str = str(result).lower()
+    expected_str = str(expected).lower()
+    return 1.0 if expected_str in result_str else 0.0
+
+
+def boolean(result: Any, expected: Any, **options) -> float:
+    """Boolean equality check."""
+    return 1.0 if bool(result) == bool(expected) else 0.0
+
+
+def file_exists(result: Any, expected: Any, **options) -> float:
+    """Check if file exists."""
+    path = result if result else expected
+    if path and Path(path).exists():
+        return 1.0
+    return 0.0
+
+
+def get_metric(name: str):
+    """Look up a metric function by name. Returns None if not found."""
+    return _METRICS.get(name)
+
+
+_METRICS = {
+    "exact_match": exact_match,
+    "fuzzy_match": fuzzy_match,
+    "contains": contains,
+    "boolean": boolean,
+    "file_exists": file_exists,
+}

--- a/openadapt_evals/server/evaluate_endpoint.py
+++ b/openadapt_evals/server/evaluate_endpoint.py
@@ -541,57 +541,23 @@ def create_evaluate_blueprint(
     return bp
 
 
-# Standalone metrics implementations for when WAA evaluators are not available
-# These provide basic functionality without requiring WAA
+# Standalone metrics implementations — delegates to shared evaluation.metrics module
 
 
 class StandaloneMetrics:
     """Standalone metric implementations.
 
-    These are fallback implementations that can be used when WAA's
-    evaluators are not available (e.g., for testing or standalone use).
+    Thin wrapper around ``openadapt_evals.evaluation.metrics`` so that
+    existing callers (and tests) that reference ``StandaloneMetrics.method``
+    continue to work.
     """
 
-    @staticmethod
-    def exact_match(result: Any, expected: Any, **options) -> float:
-        """Exact string/value match."""
-        if result == expected:
-            return 1.0
-        # Try string comparison
-        if str(result).strip() == str(expected).strip():
-            return 1.0
-        return 0.0
-
-    @staticmethod
-    def fuzzy_match(result: Any, expected: Any, threshold: float = 0.8, **options) -> float:
-        """Fuzzy string matching."""
-        try:
-            from rapidfuzz import fuzz
-
-            score = fuzz.ratio(str(result), str(expected)) / 100.0
-            return 1.0 if score >= threshold else score
-        except ImportError:
-            # Fallback to simple containment check
-            result_str = str(result).lower()
-            expected_str = str(expected).lower()
-            if expected_str in result_str or result_str in expected_str:
-                return 0.8
-            return 0.0
-
-    @staticmethod
-    def contains(result: Any, expected: Any, **options) -> float:
-        """Check if result contains expected."""
-        result_str = str(result).lower()
-        expected_str = str(expected).lower()
-        return 1.0 if expected_str in result_str else 0.0
-
-    @staticmethod
-    def file_exists(result: Any, expected: Any, **options) -> float:
-        """Check if file exists."""
-        path = result if result else expected
-        if path and Path(path).exists():
-            return 1.0
-        return 0.0
+    from openadapt_evals.evaluation.metrics import (
+        exact_match,
+        fuzzy_match,
+        contains,
+        file_exists,
+    )
 
 
 class StandaloneGetters:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,70 @@
+"""Tests for shared evaluation metrics module."""
+
+from openadapt_evals.evaluation.metrics import (
+    exact_match,
+    fuzzy_match,
+    contains,
+    boolean,
+    get_metric,
+)
+
+
+class TestExactMatch:
+    def test_equal_strings(self):
+        assert exact_match("hello", "hello") == 1.0
+
+    def test_unequal_strings(self):
+        assert exact_match("hello", "world") == 0.0
+
+    def test_whitespace_stripped(self):
+        assert exact_match("hello ", " hello") == 1.0
+
+    def test_numbers(self):
+        assert exact_match(42, 42) == 1.0
+        assert exact_match(42, 43) == 0.0
+
+
+class TestFuzzyMatch:
+    def test_exact_match_high_score(self):
+        # With rapidfuzz: 1.0 (above threshold). Without: 0.8 (substring match).
+        assert fuzzy_match("hello", "hello") >= 0.8
+
+    def test_completely_different(self):
+        score = fuzzy_match("abc", "xyz")
+        assert score < 0.5
+
+    def test_containment_fallback(self):
+        # "world" is contained in "hello world" — should score > 0
+        assert fuzzy_match("hello world", "world") > 0.0
+
+
+class TestContains:
+    def test_positive(self):
+        assert contains("hello world", "world") == 1.0
+
+    def test_negative(self):
+        assert contains("hello world", "foo") == 0.0
+
+    def test_case_insensitive(self):
+        assert contains("Hello World", "WORLD") == 1.0
+
+
+class TestBoolean:
+    def test_both_truthy(self):
+        assert boolean(1, True) == 1.0
+
+    def test_both_falsy(self):
+        assert boolean(0, False) == 1.0
+
+    def test_mismatch(self):
+        assert boolean(1, False) == 0.0
+
+
+class TestGetMetric:
+    def test_known_metric(self):
+        assert get_metric("exact_match") is exact_match
+        assert get_metric("fuzzy_match") is fuzzy_match
+        assert get_metric("contains") is contains
+
+    def test_unknown_returns_none(self):
+        assert get_metric("nonexistent") is None


### PR DESCRIPTION
## Summary
- Create `evaluation/metrics.py` as single source of truth for metric functions
- `client.py` fallback now delegates to shared module (was word-set overlap, now rapidfuzz with fallback)
- `evaluate_endpoint.py` `StandaloneMetrics` now wraps shared module
- Add 15 tests for the shared metrics module

Resolves the eval path divergence documented in client.py and STATUS.md (Tier 2).

## What changed
| Metric | Before (client.py) | Before (endpoint) | After (both) |
|--------|--------------------|--------------------|--------------|
| fuzzy_match | word-set intersection | rapidfuzz + substring fallback | rapidfuzz + substring fallback |
| exact_match | `actual == expected` | `actual == expected` + strip | `actual == expected` + strip |
| contains | case-insensitive substring | case-insensitive substring | case-insensitive substring |

## Test plan
- [x] All 26 existing evaluate_endpoint tests pass
- [x] All 15 new metrics tests pass
- [x] 507 total tests pass (22 pre-existing failures in test_setup_handlers.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)