### PR TITLE
feat: add 4-layer WAA probe for per-layer diagnostics

### DIFF
--- a/openadapt_evals/benchmarks/cli.py
+++ b/openadapt_evals/benchmarks/cli.py
@@ -890,7 +890,42 @@ def cmd_probe(args: argparse.Namespace) -> int:
         return 1
 
     server_url = args.server
+    detailed = args.detailed or args.json_output
+    layers = args.layers.split(",") if args.layers else None
+    if layers:
+        detailed = True
 
+    if detailed:
+        from openadapt_evals.infrastructure.probe import (
+            multi_layer_probe,
+            print_probe_results,
+        )
+
+        max_attempts = args.wait_attempts if args.wait else 1
+        attempt = 0
+
+        while attempt < max_attempts:
+            attempt += 1
+            result = multi_layer_probe(
+                server_url,
+                layers=layers,
+                evaluate_url=args.evaluate_url,
+            )
+            if args.json_output:
+                print(result.to_json())
+            else:
+                print_probe_results(result)
+
+            if result.overall_ready:
+                return 0
+
+            if args.wait and attempt < max_attempts:
+                print(f"Attempt {attempt}/{max_attempts}: not ready, retrying in {args.wait_interval}s...")
+                time.sleep(args.wait_interval)
+
+        return 0 if result.overall_ready else 1
+
+    # Default binary probe (unchanged)
     print(f"Probing WAA server at {server_url}...")
 
     max_attempts = args.wait_attempts if args.wait else 1
@@ -2264,6 +2299,14 @@ def main() -> int:
                              help="Max attempts when waiting")
     probe_parser.add_argument("--wait-interval", type=int, default=5,
                              help="Seconds between attempts")
+    probe_parser.add_argument("--detailed", action="store_true",
+                             help="Run 4-layer probe (screenshot, a11y, action, score)")
+    probe_parser.add_argument("--json", dest="json_output", action="store_true",
+                             help="Output JSON (implies --detailed)")
+    probe_parser.add_argument("--layers", type=str, default=None,
+                             help="Comma-separated layer subset (e.g. screenshot,a11y)")
+    probe_parser.add_argument("--evaluate-url", type=str, default=None,
+                             help="Separate URL for score layer (e.g. http://localhost:5051)")
 
     # Generate viewer
     view_parser = subparsers.add_parser("view", help="Generate HTML viewer for results")

--- a/openadapt_evals/infrastructure/__init__.py
+++ b/openadapt_evals/infrastructure/__init__.py
@@ -47,6 +47,12 @@ from openadapt_evals.infrastructure.screen_stability import (
     wait_for_stable_screen,
 )
 from openadapt_evals.infrastructure.ssh_tunnel import SSHTunnelManager, get_tunnel_manager
+from openadapt_evals.infrastructure.probe import (
+    MultiLayerProbeResult,
+    ProbeLayerResult,
+    multi_layer_probe,
+    print_probe_results,
+)
 from openadapt_evals.infrastructure.vm_ip import resolve_vm_ip
 from openadapt_evals.infrastructure.vm_monitor import VMMonitor, VMConfig
 from openadapt_evals.infrastructure.vm_provider import VMProvider
@@ -60,8 +66,10 @@ __all__ = [
     "AWSVMManager",
     "AzureOpsTracker",
     "AzureVMManager",
+    "MultiLayerProbeResult",
     "PoolManager",
     "PoolRunResult",
+    "ProbeLayerResult",
     "QEMUResetManager",
     "VMMonitor",
     "VMConfig",
@@ -69,6 +77,8 @@ __all__ = [
     "SSHTunnelManager",
     "compare_screenshots",
     "get_tunnel_manager",
+    "multi_layer_probe",
+    "print_probe_results",
     "resolve_vm_ip",
     "wait_for_stable_screen",
 ]

--- a/openadapt_evals/infrastructure/probe.py
+++ b/openadapt_evals/infrastructure/probe.py
@@ -1,0 +1,424 @@
+"""Multi-layer WAA probe for per-layer diagnostics.
+
+Probes 4 layers of the WAA stack using existing endpoints:
+1. Screenshot — GET /screenshot (PNG capture working?)
+2. Accessibility — GET /accessibility?backend=uia (a11y tree populated?)
+3. Action — POST /execute with pyautogui.position() (action pipeline working?)
+4. Score — POST /evaluate with echo probe_test (full getter→metric→score path?)
+
+All probes are read-only and safe to run at any time.
+
+Usage:
+    from openadapt_evals.infrastructure.probe import multi_layer_probe
+
+    result = multi_layer_probe("http://localhost:5001")
+    print_probe_results(result)
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+
+import requests
+
+# Layer names in data-flow order
+LAYER_SCREENSHOT = "screenshot"
+LAYER_A11Y = "a11y"
+LAYER_ACTION = "action"
+LAYER_SCORE = "score"
+
+ALL_LAYERS = [LAYER_SCREENSHOT, LAYER_A11Y, LAYER_ACTION, LAYER_SCORE]
+
+# PNG magic bytes
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+@dataclass
+class ProbeLayerResult:
+    """Result from probing a single WAA layer."""
+
+    layer: str
+    success: bool
+    latency_ms: float
+    details: dict = field(default_factory=dict)
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+
+@dataclass
+class MultiLayerProbeResult:
+    """Aggregated result from probing multiple WAA layers."""
+
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+    server_url: str = ""
+    layers: list[ProbeLayerResult] = field(default_factory=list)
+    overall_ready: bool = False
+    summary: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "timestamp": self.timestamp,
+            "server_url": self.server_url,
+            "layers": [layer.to_dict() for layer in self.layers],
+            "overall_ready": self.overall_ready,
+            "summary": self.summary,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+
+def _count_a11y_elements(text: str) -> int:
+    """Count elements in an accessibility tree response.
+
+    Handles both JSON arrays and XML-like text.
+    """
+    try:
+        data = json.loads(text)
+        if isinstance(data, list):
+            return len(data)
+        if isinstance(data, dict):
+            # Single element or wrapper
+            children = data.get("children", data.get("elements", []))
+            if isinstance(children, list):
+                return len(children) + 1
+            return 1
+    except (json.JSONDecodeError, TypeError):
+        pass
+    # XML/text fallback: count opening tags or Name= occurrences
+    count = text.count("Name=") + text.count("<Name")
+    if count == 0:
+        # Try counting lines with content as a rough proxy
+        count = sum(1 for line in text.splitlines() if line.strip())
+    return count
+
+
+def _build_summary(layers: list[ProbeLayerResult]) -> str:
+    """Build a one-line summary from layer results."""
+    parts = []
+    for layer in layers:
+        status = "PASS" if layer.success else ("SKIP" if layer.error == "Skipped" else "FAIL")
+        parts.append(f"{layer.layer}:{status}")
+    return " | ".join(parts)
+
+
+def probe_layer_screenshot(url: str, timeout: float = 10) -> ProbeLayerResult:
+    """Probe the screenshot layer via GET /screenshot.
+
+    Validates that the response contains PNG data.
+    """
+    start = time.monotonic()
+    try:
+        resp = requests.get(f"{url}/screenshot", timeout=timeout)
+        latency = (time.monotonic() - start) * 1000
+        if resp.status_code != 200:
+            return ProbeLayerResult(
+                layer=LAYER_SCREENSHOT,
+                success=False,
+                latency_ms=latency,
+                error=f"HTTP {resp.status_code}",
+                details={"status_code": resp.status_code},
+            )
+        content = resp.content
+        is_png = content[:8] == _PNG_MAGIC
+        size = len(content)
+        return ProbeLayerResult(
+            layer=LAYER_SCREENSHOT,
+            success=is_png and size > 0,
+            latency_ms=latency,
+            details={"is_png": is_png, "size_bytes": size},
+            error=None if (is_png and size > 0) else "Response is not a valid PNG",
+        )
+    except requests.ConnectionError as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCREENSHOT, success=False, latency_ms=latency,
+            error=f"Connection error: {e}",
+        )
+    except requests.Timeout:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCREENSHOT, success=False, latency_ms=latency,
+            error="Timeout",
+        )
+    except Exception as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCREENSHOT, success=False, latency_ms=latency,
+            error=str(e),
+        )
+
+
+def probe_layer_a11y(url: str, timeout: float = 10) -> ProbeLayerResult:
+    """Probe the accessibility layer via GET /accessibility?backend=uia.
+
+    Validates that the response is non-empty and contains element data.
+    """
+    start = time.monotonic()
+    try:
+        resp = requests.get(f"{url}/accessibility", params={"backend": "uia"}, timeout=timeout)
+        latency = (time.monotonic() - start) * 1000
+        if resp.status_code != 200:
+            return ProbeLayerResult(
+                layer=LAYER_A11Y,
+                success=False,
+                latency_ms=latency,
+                error=f"HTTP {resp.status_code}",
+                details={"status_code": resp.status_code},
+            )
+        text = resp.text.strip()
+        if not text:
+            return ProbeLayerResult(
+                layer=LAYER_A11Y,
+                success=False,
+                latency_ms=latency,
+                error="Empty accessibility tree",
+                details={"element_count": 0},
+            )
+        element_count = _count_a11y_elements(text)
+        return ProbeLayerResult(
+            layer=LAYER_A11Y,
+            success=element_count > 0,
+            latency_ms=latency,
+            details={"element_count": element_count, "response_length": len(text)},
+            error=None if element_count > 0 else "No elements found in accessibility tree",
+        )
+    except requests.ConnectionError as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_A11Y, success=False, latency_ms=latency,
+            error=f"Connection error: {e}",
+        )
+    except requests.Timeout:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_A11Y, success=False, latency_ms=latency,
+            error="Timeout",
+        )
+    except Exception as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_A11Y, success=False, latency_ms=latency,
+            error=str(e),
+        )
+
+
+def probe_layer_action(url: str, timeout: float = 10) -> ProbeLayerResult:
+    """Probe the action layer via POST /execute with pyautogui.position().
+
+    Uses python -c wrapper per WAA /execute command format requirements.
+    Validates that output contains "Point" (pyautogui.position() returns Point(x, y)).
+    """
+    command = 'python -c "import pyautogui; print(pyautogui.position())"'
+    start = time.monotonic()
+    try:
+        resp = requests.post(
+            f"{url}/execute",
+            json={"command": command},
+            timeout=timeout,
+        )
+        latency = (time.monotonic() - start) * 1000
+        if resp.status_code != 200:
+            return ProbeLayerResult(
+                layer=LAYER_ACTION,
+                success=False,
+                latency_ms=latency,
+                error=f"HTTP {resp.status_code}",
+                details={"status_code": resp.status_code},
+            )
+        try:
+            data = resp.json()
+        except (ValueError, json.JSONDecodeError):
+            data = {"output": resp.text}
+        output = str(data.get("output", data.get("result", "")))
+        has_point = "Point" in output
+        return ProbeLayerResult(
+            layer=LAYER_ACTION,
+            success=has_point,
+            latency_ms=latency,
+            details={"output": output, "command": command},
+            error=None if has_point else f"Expected 'Point' in output, got: {output[:200]}",
+        )
+    except requests.ConnectionError as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_ACTION, success=False, latency_ms=latency,
+            error=f"Connection error: {e}",
+        )
+    except requests.Timeout:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_ACTION, success=False, latency_ms=latency,
+            error="Timeout",
+        )
+    except Exception as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_ACTION, success=False, latency_ms=latency,
+            error=str(e),
+        )
+
+
+def probe_layer_score(
+    url: str,
+    evaluate_url: str | None = None,
+    timeout: float = 10,
+) -> ProbeLayerResult:
+    """Probe the scoring layer via POST /evaluate.
+
+    Sends ``echo probe_test`` with ``exact_match`` metric to validate the
+    full getter -> metric -> score path. Uses a separate ``evaluate_url``
+    if provided (evaluate server typically runs on port 5051).
+    """
+    target = evaluate_url or url
+    payload = {
+        "command": "echo probe_test",
+        "expected": "probe_test",
+        "metric": "exact_match",
+    }
+    start = time.monotonic()
+    try:
+        resp = requests.post(f"{target}/evaluate", json=payload, timeout=timeout)
+        latency = (time.monotonic() - start) * 1000
+        if resp.status_code != 200:
+            return ProbeLayerResult(
+                layer=LAYER_SCORE,
+                success=False,
+                latency_ms=latency,
+                error=f"HTTP {resp.status_code}",
+                details={"status_code": resp.status_code, "evaluate_url": target},
+            )
+        try:
+            data = resp.json()
+        except (ValueError, json.JSONDecodeError):
+            data = {}
+        # Look for a numeric score in common response shapes
+        score = data.get("score", data.get("result", data.get("value")))
+        has_score = score is not None and isinstance(score, (int, float))
+        return ProbeLayerResult(
+            layer=LAYER_SCORE,
+            success=has_score,
+            latency_ms=latency,
+            details={"score": score, "response": data, "evaluate_url": target},
+            error=None if has_score else f"No numeric score in response: {data}",
+        )
+    except requests.ConnectionError as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCORE, success=False, latency_ms=latency,
+            error=f"Connection error: {e}",
+            details={"evaluate_url": target},
+        )
+    except requests.Timeout:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCORE, success=False, latency_ms=latency,
+            error="Timeout",
+            details={"evaluate_url": target},
+        )
+    except Exception as e:
+        latency = (time.monotonic() - start) * 1000
+        return ProbeLayerResult(
+            layer=LAYER_SCORE, success=False, latency_ms=latency,
+            error=str(e),
+            details={"evaluate_url": target},
+        )
+
+
+# Map layer names to probe functions
+_LAYER_FUNCS = {
+    LAYER_SCREENSHOT: lambda url, timeout, **kw: probe_layer_screenshot(url, timeout),
+    LAYER_A11Y: lambda url, timeout, **kw: probe_layer_a11y(url, timeout),
+    LAYER_ACTION: lambda url, timeout, **kw: probe_layer_action(url, timeout),
+    LAYER_SCORE: lambda url, timeout, **kw: probe_layer_score(url, kw.get("evaluate_url"), timeout),
+}
+
+
+def multi_layer_probe(
+    server_url: str,
+    timeout: float = 10,
+    layers: list[str] | None = None,
+    bail_early: bool = True,
+    evaluate_url: str | None = None,
+) -> MultiLayerProbeResult:
+    """Run a multi-layer probe against a WAA server.
+
+    Args:
+        server_url: Base URL of the WAA server (e.g. http://localhost:5001).
+        timeout: Per-layer timeout in seconds.
+        layers: Subset of layers to probe. Defaults to all 4 layers.
+        bail_early: If True, skip remaining layers after first failure.
+        evaluate_url: Separate URL for the score layer (e.g. http://localhost:5051).
+
+    Returns:
+        MultiLayerProbeResult with per-layer results.
+    """
+    selected = layers or list(ALL_LAYERS)
+    # Validate layer names
+    for name in selected:
+        if name not in _LAYER_FUNCS:
+            raise ValueError(f"Unknown layer: {name!r}. Valid layers: {ALL_LAYERS}")
+
+    result = MultiLayerProbeResult(server_url=server_url)
+    failed = False
+
+    for name in ALL_LAYERS:
+        if name not in selected:
+            continue
+        if failed and bail_early:
+            result.layers.append(ProbeLayerResult(
+                layer=name, success=False, latency_ms=0, error="Skipped",
+            ))
+            continue
+        layer_result = _LAYER_FUNCS[name](server_url, timeout, evaluate_url=evaluate_url)
+        result.layers.append(layer_result)
+        if not layer_result.success:
+            failed = True
+
+    result.overall_ready = all(lr.success for lr in result.layers)
+    result.summary = _build_summary(result.layers)
+    return result
+
+
+def print_probe_results(result: MultiLayerProbeResult) -> None:
+    """Print probe results in a terminal-friendly format."""
+    print(f"\nWAA Multi-Layer Probe: {result.server_url}")
+    print(f"Timestamp: {result.timestamp}")
+    print("-" * 60)
+
+    for layer in result.layers:
+        if layer.success:
+            status = "PASS"
+        elif layer.error == "Skipped":
+            status = "SKIP"
+        else:
+            status = "FAIL"
+        print(f"  [{status}] {layer.layer:<12} {layer.latency_ms:>8.1f}ms", end="")
+        if layer.error and layer.error != "Skipped":
+            print(f"  error: {layer.error}")
+        elif layer.details:
+            # Show key details inline
+            detail_parts = []
+            for k, v in layer.details.items():
+                if k in ("command", "response", "evaluate_url"):
+                    continue
+                detail_parts.append(f"{k}={v}")
+            if detail_parts:
+                print(f"  ({', '.join(detail_parts)})")
+            else:
+                print()
+        else:
+            print()
+
+    print("-" * 60)
+    overall = "READY" if result.overall_ready else "NOT READY"
+    print(f"Overall: {overall}  [{result.summary}]")
+    print()

--- a/openadapt_evals/infrastructure/vm_monitor.py
+++ b/openadapt_evals/infrastructure/vm_monitor.py
@@ -83,6 +83,7 @@ class VMStatus:
     vnc_reachable: bool = False
     waa_ready: bool = False
     waa_probe_response: str | None = None
+    waa_detailed_probe: dict | None = None
     container_running: bool = False
     container_logs: str | None = None
     disk_usage_gb: float | None = None
@@ -97,6 +98,7 @@ class VMStatus:
             "vnc_reachable": self.vnc_reachable,
             "waa_ready": self.waa_ready,
             "waa_probe_response": self.waa_probe_response,
+            "waa_detailed_probe": self.waa_detailed_probe,
             "container_running": self.container_running,
             "container_logs": self.container_logs,
             "disk_usage_gb": self.disk_usage_gb,
@@ -181,6 +183,37 @@ class VMMonitor:
             return False, response or None
         except (subprocess.TimeoutExpired, Exception) as e:
             return False, str(e)
+
+    def check_waa_detailed(
+        self,
+        evaluate_url: str | None = None,
+        layers: list[str] | None = None,
+    ) -> dict | None:
+        """Run a multi-layer probe against the WAA server via SSH tunnel.
+
+        Requires the SSH tunnel to be active (WAA on localhost:{waa_port}).
+
+        Args:
+            evaluate_url: Separate URL for the score layer.
+            layers: Subset of layers to probe.
+
+        Returns:
+            Probe result dict, or None on error.
+        """
+        try:
+            from openadapt_evals.infrastructure.probe import multi_layer_probe
+
+            server_url = f"http://localhost:{self.config.waa_port}"
+            result = multi_layer_probe(
+                server_url,
+                timeout=self.timeout,
+                layers=layers,
+                evaluate_url=evaluate_url,
+            )
+            return result.to_dict()
+        except Exception as e:
+            logger.debug(f"Detailed probe failed: {e}")
+            return None
 
     def get_container_status(self) -> tuple[bool, str | None]:
         """Check container status and get recent logs.

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,0 +1,482 @@
+"""Tests for multi-layer WAA probe."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as _requests
+
+from openadapt_evals.infrastructure.probe import (
+    MultiLayerProbeResult,
+    ProbeLayerResult,
+    _build_summary,
+    _count_a11y_elements,
+    multi_layer_probe,
+    print_probe_results,
+    probe_layer_a11y,
+    probe_layer_action,
+    probe_layer_score,
+    probe_layer_screenshot,
+)
+
+# PNG magic bytes for a minimal valid PNG header
+_PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
+# Patch targets — patch on the module that imported requests
+_PATCH_GET = "openadapt_evals.infrastructure.probe.requests.get"
+_PATCH_POST = "openadapt_evals.infrastructure.probe.requests.post"
+
+
+def _make_png_bytes(size: int = 100) -> bytes:
+    """Create fake PNG data with valid magic bytes."""
+    return _PNG_HEADER + b"\x00" * size
+
+
+# ============================================================================
+# Dataclass serialization
+# ============================================================================
+
+
+class TestProbeLayerResult:
+    def test_to_dict(self):
+        r = ProbeLayerResult(layer="screenshot", success=True, latency_ms=42.5, details={"size_bytes": 1024})
+        d = r.to_dict()
+        assert d["layer"] == "screenshot"
+        assert d["success"] is True
+        assert d["latency_ms"] == 42.5
+        assert d["details"]["size_bytes"] == 1024
+        assert d["error"] is None
+
+    def test_to_json(self):
+        r = ProbeLayerResult(layer="a11y", success=False, latency_ms=10, error="Timeout")
+        j = r.to_json()
+        data = json.loads(j)
+        assert data["layer"] == "a11y"
+        assert data["success"] is False
+        assert data["error"] == "Timeout"
+
+    def test_defaults(self):
+        r = ProbeLayerResult(layer="test", success=True, latency_ms=0)
+        assert r.details == {}
+        assert r.error is None
+
+
+class TestMultiLayerProbeResult:
+    def test_to_dict(self):
+        layer = ProbeLayerResult(layer="screenshot", success=True, latency_ms=50)
+        r = MultiLayerProbeResult(
+            server_url="http://localhost:5001",
+            layers=[layer],
+            overall_ready=True,
+            summary="screenshot:PASS",
+        )
+        d = r.to_dict()
+        assert d["server_url"] == "http://localhost:5001"
+        assert len(d["layers"]) == 1
+        assert d["layers"][0]["layer"] == "screenshot"
+        assert d["overall_ready"] is True
+
+    def test_to_json(self):
+        r = MultiLayerProbeResult(server_url="http://test", layers=[], overall_ready=False, summary="")
+        j = r.to_json()
+        data = json.loads(j)
+        assert data["server_url"] == "http://test"
+        assert data["layers"] == []
+
+    def test_timestamp_auto_set(self):
+        r = MultiLayerProbeResult()
+        assert r.timestamp  # non-empty
+
+
+# ============================================================================
+# Screenshot layer
+# ============================================================================
+
+
+class TestProbeLayerScreenshot:
+    @patch(_PATCH_GET)
+    def test_png_success(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = _make_png_bytes(500)
+        mock_get.return_value = resp
+        result = probe_layer_screenshot("http://localhost:5001", timeout=5)
+        assert result.success is True
+        assert result.layer == "screenshot"
+        assert result.details["is_png"] is True
+        assert result.details["size_bytes"] > 0
+        assert result.error is None
+
+    @patch(_PATCH_GET)
+    def test_non_png_failure(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"<html>not a png</html>"
+        mock_get.return_value = resp
+        result = probe_layer_screenshot("http://localhost:5001")
+        assert result.success is False
+        assert result.details["is_png"] is False
+
+    @patch(_PATCH_GET)
+    def test_http_error(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 500
+        mock_get.return_value = resp
+        result = probe_layer_screenshot("http://localhost:5001")
+        assert result.success is False
+        assert "HTTP 500" in result.error
+
+    @patch(_PATCH_GET)
+    def test_connection_error(self, mock_get):
+        mock_get.side_effect = _requests.ConnectionError("refused")
+        result = probe_layer_screenshot("http://localhost:5001")
+        assert result.success is False
+        assert "Connection error" in result.error
+
+    @patch(_PATCH_GET)
+    def test_timeout(self, mock_get):
+        mock_get.side_effect = _requests.Timeout()
+        result = probe_layer_screenshot("http://localhost:5001")
+        assert result.success is False
+        assert result.error == "Timeout"
+
+
+# ============================================================================
+# Accessibility layer
+# ============================================================================
+
+
+class TestProbeLayerA11y:
+    @patch(_PATCH_GET)
+    def test_json_success(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = json.dumps([{"Name": "Desktop"}, {"Name": "Taskbar"}])
+        mock_get.return_value = resp
+        result = probe_layer_a11y("http://localhost:5001")
+        assert result.success is True
+        assert result.details["element_count"] == 2
+
+    @patch(_PATCH_GET)
+    def test_xml_success(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = 'Name="Desktop" Role="Window"\nName="Taskbar" Role="Pane"'
+        mock_get.return_value = resp
+        result = probe_layer_a11y("http://localhost:5001")
+        assert result.success is True
+        assert result.details["element_count"] == 2
+
+    @patch(_PATCH_GET)
+    def test_empty_tree_failure(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = ""
+        mock_get.return_value = resp
+        result = probe_layer_a11y("http://localhost:5001")
+        assert result.success is False
+        assert "Empty" in result.error
+
+    @patch(_PATCH_GET)
+    def test_http_error(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 503
+        mock_get.return_value = resp
+        result = probe_layer_a11y("http://localhost:5001")
+        assert result.success is False
+        assert "HTTP 503" in result.error
+
+    @patch(_PATCH_GET)
+    def test_passes_uia_backend(self, mock_get):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = json.dumps([{"Name": "Test"}])
+        mock_get.return_value = resp
+        probe_layer_a11y("http://localhost:5001")
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args
+        assert call_kwargs[1]["params"] == {"backend": "uia"}
+
+
+# ============================================================================
+# Action layer
+# ============================================================================
+
+
+class TestProbeLayerAction:
+    @patch(_PATCH_POST)
+    def test_point_output_success(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"output": "Point(x=500, y=400)"}
+        mock_post.return_value = resp
+        result = probe_layer_action("http://localhost:5001")
+        assert result.success is True
+        assert "Point" in result.details["output"]
+
+    @patch(_PATCH_POST)
+    def test_bad_output_failure(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"output": "error: display not found"}
+        mock_post.return_value = resp
+        result = probe_layer_action("http://localhost:5001")
+        assert result.success is False
+        assert "Expected 'Point'" in result.error
+
+    @patch(_PATCH_POST)
+    def test_correct_command_sent(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"output": "Point(x=0, y=0)"}
+        mock_post.return_value = resp
+        probe_layer_action("http://localhost:5001")
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"]
+        assert "python -c" in payload["command"]
+        assert "pyautogui.position()" in payload["command"]
+
+    @patch(_PATCH_POST)
+    def test_http_error(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 500
+        mock_post.return_value = resp
+        result = probe_layer_action("http://localhost:5001")
+        assert result.success is False
+
+    @patch(_PATCH_POST)
+    def test_non_json_response(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.side_effect = ValueError("not json")
+        resp.text = "Point(x=100, y=200)"
+        mock_post.return_value = resp
+        result = probe_layer_action("http://localhost:5001")
+        # Falls back to resp.text, data = {"output": resp.text}
+        assert result.success is True
+
+
+# ============================================================================
+# Score layer
+# ============================================================================
+
+
+class TestProbeLayerScore:
+    @patch(_PATCH_POST)
+    def test_success(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"score": 1.0}
+        mock_post.return_value = resp
+        result = probe_layer_score("http://localhost:5001")
+        assert result.success is True
+        assert result.details["score"] == 1.0
+
+    @patch(_PATCH_POST)
+    def test_evaluate_url_routing(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"score": 0.5}
+        mock_post.return_value = resp
+        result = probe_layer_score("http://localhost:5001", evaluate_url="http://localhost:5051")
+        assert result.success is True
+        call_args = mock_post.call_args
+        assert "localhost:5051" in call_args[0][0]
+        assert result.details["evaluate_url"] == "http://localhost:5051"
+
+    @patch(_PATCH_POST)
+    def test_http_error(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 502
+        mock_post.return_value = resp
+        result = probe_layer_score("http://localhost:5001")
+        assert result.success is False
+        assert "HTTP 502" in result.error
+
+    @patch(_PATCH_POST)
+    def test_no_score_in_response(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"error": "metric not found"}
+        mock_post.return_value = resp
+        result = probe_layer_score("http://localhost:5001")
+        assert result.success is False
+        assert "No numeric score" in result.error
+
+    @patch(_PATCH_POST)
+    def test_sends_correct_payload(self, mock_post):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"score": 1.0}
+        mock_post.return_value = resp
+        probe_layer_score("http://localhost:5001")
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs[1]["json"]
+        assert payload["command"] == "echo probe_test"
+        assert payload["expected"] == "probe_test"
+        assert payload["metric"] == "exact_match"
+
+
+# ============================================================================
+# Multi-layer orchestrator
+# ============================================================================
+
+
+class TestMultiLayerProbe:
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_score")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_action")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_a11y")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_screenshot")
+    def test_all_pass(self, mock_ss, mock_a11y, mock_action, mock_score):
+        mock_ss.return_value = ProbeLayerResult(layer="screenshot", success=True, latency_ms=50)
+        mock_a11y.return_value = ProbeLayerResult(layer="a11y", success=True, latency_ms=30)
+        mock_action.return_value = ProbeLayerResult(layer="action", success=True, latency_ms=40)
+        mock_score.return_value = ProbeLayerResult(layer="score", success=True, latency_ms=60)
+
+        result = multi_layer_probe("http://localhost:5001")
+        assert result.overall_ready is True
+        assert len(result.layers) == 4
+        assert all(lr.success for lr in result.layers)
+
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_score")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_action")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_a11y")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_screenshot")
+    def test_bail_early(self, mock_ss, mock_a11y, mock_action, mock_score):
+        mock_ss.return_value = ProbeLayerResult(layer="screenshot", success=False, latency_ms=50, error="HTTP 500")
+
+        result = multi_layer_probe("http://localhost:5001", bail_early=True)
+        assert result.overall_ready is False
+        assert len(result.layers) == 4
+        assert result.layers[0].success is False
+        for lr in result.layers[1:]:
+            assert lr.error == "Skipped"
+            assert lr.success is False
+        mock_a11y.assert_not_called()
+        mock_action.assert_not_called()
+        mock_score.assert_not_called()
+
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_score")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_action")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_a11y")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_screenshot")
+    def test_no_bail_early(self, mock_ss, mock_a11y, mock_action, mock_score):
+        mock_ss.return_value = ProbeLayerResult(layer="screenshot", success=False, latency_ms=50, error="HTTP 500")
+        mock_a11y.return_value = ProbeLayerResult(layer="a11y", success=True, latency_ms=30)
+        mock_action.return_value = ProbeLayerResult(layer="action", success=True, latency_ms=40)
+        mock_score.return_value = ProbeLayerResult(layer="score", success=True, latency_ms=60)
+
+        result = multi_layer_probe("http://localhost:5001", bail_early=False)
+        assert result.overall_ready is False
+        assert len(result.layers) == 4
+        mock_a11y.assert_called_once()
+        mock_action.assert_called_once()
+        mock_score.assert_called_once()
+
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_a11y")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_screenshot")
+    def test_subset_layers(self, mock_ss, mock_a11y):
+        mock_ss.return_value = ProbeLayerResult(layer="screenshot", success=True, latency_ms=50)
+        mock_a11y.return_value = ProbeLayerResult(layer="a11y", success=True, latency_ms=30)
+
+        result = multi_layer_probe("http://localhost:5001", layers=["screenshot", "a11y"])
+        assert result.overall_ready is True
+        assert len(result.layers) == 2
+        assert result.layers[0].layer == "screenshot"
+        assert result.layers[1].layer == "a11y"
+
+    def test_invalid_layer_name(self):
+        with pytest.raises(ValueError, match="Unknown layer"):
+            multi_layer_probe("http://localhost:5001", layers=["bogus"])
+
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_score")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_action")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_a11y")
+    @patch("openadapt_evals.infrastructure.probe.probe_layer_screenshot")
+    def test_evaluate_url_passed_to_score(self, mock_ss, mock_a11y, mock_action, mock_score):
+        mock_ss.return_value = ProbeLayerResult(layer="screenshot", success=True, latency_ms=10)
+        mock_a11y.return_value = ProbeLayerResult(layer="a11y", success=True, latency_ms=10)
+        mock_action.return_value = ProbeLayerResult(layer="action", success=True, latency_ms=10)
+        mock_score.return_value = ProbeLayerResult(layer="score", success=True, latency_ms=10)
+
+        multi_layer_probe("http://localhost:5001", evaluate_url="http://localhost:5051")
+        mock_score.assert_called_once_with("http://localhost:5001", "http://localhost:5051", 10)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+class TestCountElements:
+    def test_json_array(self):
+        assert _count_a11y_elements('[{"Name": "A"}, {"Name": "B"}]') == 2
+
+    def test_json_dict_with_children(self):
+        assert _count_a11y_elements('{"children": [{"Name": "A"}, {"Name": "B"}]}') == 3
+
+    def test_xml_name_equals(self):
+        assert _count_a11y_elements('Name="A"\nName="B"\nName="C"') == 3
+
+    def test_empty_string(self):
+        assert _count_a11y_elements("") == 0
+
+    def test_plain_text_lines(self):
+        text = "line1\nline2\nline3"
+        assert _count_a11y_elements(text) == 3
+
+
+class TestBuildSummary:
+    def test_all_pass(self):
+        layers = [
+            ProbeLayerResult(layer="screenshot", success=True, latency_ms=0),
+            ProbeLayerResult(layer="a11y", success=True, latency_ms=0),
+        ]
+        summary = _build_summary(layers)
+        assert "screenshot:PASS" in summary
+        assert "a11y:PASS" in summary
+
+    def test_fail_and_skip(self):
+        layers = [
+            ProbeLayerResult(layer="screenshot", success=False, latency_ms=0, error="HTTP 500"),
+            ProbeLayerResult(layer="a11y", success=False, latency_ms=0, error="Skipped"),
+        ]
+        summary = _build_summary(layers)
+        assert "screenshot:FAIL" in summary
+        assert "a11y:SKIP" in summary
+
+
+# ============================================================================
+# Print utility
+# ============================================================================
+
+
+class TestPrintProbeResults:
+    def test_smoke_no_crash(self, capsys):
+        result = MultiLayerProbeResult(
+            server_url="http://localhost:5001",
+            layers=[
+                ProbeLayerResult(layer="screenshot", success=True, latency_ms=42, details={"size_bytes": 1024}),
+                ProbeLayerResult(layer="a11y", success=False, latency_ms=100, error="Timeout"),
+                ProbeLayerResult(layer="action", success=False, latency_ms=0, error="Skipped"),
+            ],
+            overall_ready=False,
+            summary="screenshot:PASS | a11y:FAIL | action:SKIP",
+        )
+        print_probe_results(result)
+        captured = capsys.readouterr()
+        assert "PASS" in captured.out
+        assert "FAIL" in captured.out
+        assert "SKIP" in captured.out
+        assert "NOT READY" in captured.out
+
+    def test_all_pass_output(self, capsys):
+        result = MultiLayerProbeResult(
+            server_url="http://test",
+            layers=[ProbeLayerResult(layer="screenshot", success=True, latency_ms=10)],
+            overall_ready=True,
+            summary="screenshot:PASS",
+        )
+        print_probe_results(result)
+        captured = capsys.readouterr()
+        assert "READY" in captured.out


### PR DESCRIPTION
## Summary
- Adds `infrastructure/probe.py` with 4-layer WAA probe (screenshot, a11y, action, score) using existing endpoints — no server-side changes needed
- Extends `probe` CLI command with `--detailed`, `--json`, `--layers`, `--evaluate-url` flags; default binary probe unchanged
- Adds `check_waa_detailed()` to `VMMonitor` and `waa_detailed_probe` field to `VMStatus`
- 41 tests, all passing, ruff clean

## Test plan
- [x] `uv run pytest tests/test_probe.py -v` — 41/41 pass
- [x] `uv run ruff check` on new files — clean
- [x] Full test suite — no regressions (pre-existing failures only)
- [ ] Manual: `openadapt-evals probe --server http://localhost:5001 --detailed` (requires running WAA)
- [ ] Manual: `openadapt-evals probe --server http://localhost:5001 --json`
- [ ] Manual: `openadapt-evals probe --server http://localhost:5001 --layers screenshot,a11y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)