### PR TITLE
feat: evaluate openadapt-flow on WAA (demonstrate-then-replay + hybrid-as-agent) with cost-guarded dry-run

### DIFF
--- a/openadapt_evals/flow/__init__.py
+++ b/openadapt_evals/flow/__init__.py
@@ -37,6 +37,13 @@ __all__ = [
     "aggregate_replay_metrics",
     # hybrid agent
     "HybridFlowAgent",
+    # parallels local-VM environment ($0)
+    "ParallelsConfig",
+    "ParallelsSession",
+    "ParallelsTask",
+    "parallels_enabled",
+    "builtin_tasks",
+    "run_parallels_replay",
 ]
 
 _EXPORTS = {
@@ -56,6 +63,12 @@ _EXPORTS = {
         "aggregate_replay_metrics",
     ),
     "HybridFlowAgent": ("openadapt_evals.flow.hybrid_agent", "HybridFlowAgent"),
+    "ParallelsConfig": ("openadapt_evals.flow.parallels_env", "ParallelsConfig"),
+    "ParallelsSession": ("openadapt_evals.flow.parallels_env", "ParallelsSession"),
+    "ParallelsTask": ("openadapt_evals.flow.parallels_env", "ParallelsTask"),
+    "parallels_enabled": ("openadapt_evals.flow.parallels_env", "parallels_enabled"),
+    "builtin_tasks": ("openadapt_evals.flow.parallels_env", "builtin_tasks"),
+    "run_parallels_replay": ("openadapt_evals.flow.parallels_env", "run_parallels_replay"),
 }
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -72,6 +85,14 @@ if TYPE_CHECKING:  # pragma: no cover
         PerTaskReplayMetrics,
         aggregate_replay_metrics,
         run_demonstrate_then_replay,
+    )
+    from openadapt_evals.flow.parallels_env import (
+        ParallelsConfig,
+        ParallelsSession,
+        ParallelsTask,
+        builtin_tasks,
+        parallels_enabled,
+        run_parallels_replay,
     )
 
 

--- a/openadapt_evals/flow/__init__.py
+++ b/openadapt_evals/flow/__init__.py
@@ -1,0 +1,89 @@
+"""Evaluate openadapt-flow (the demonstration compiler) on WAA.
+
+Two eval modes, both scored by WAA's own task verifier:
+
+- **demonstrate-then-replay** (:mod:`openadapt_evals.flow.replay_runner`) --
+  compile ONE demonstration into a bundle and replay it via
+  :class:`openadapt_flow.backends.windows_backend.WindowsBackend` against the
+  WAA in-guest server (~0 model calls). The paradigm-correct eval for a
+  demonstration compiler.
+- **hybrid-as-agent** (:mod:`openadapt_evals.flow.hybrid_agent`) -- a
+  ``BenchmarkAgent`` the existing WAA runner can drive: compiled replay first,
+  computer-use agent fallback only on a detected halt. Directly comparable to a
+  pure agent baseline on the same tasks.
+
+Cost estimation + hard guardrails live in :mod:`openadapt_evals.flow.cost`
+(stdlib-only, importable without the ``flow`` extra or a VM).
+
+Submodules are imported lazily (PEP 562) so importing this package never pulls
+in ``openadapt_flow`` or any heavy dependency -- light CI imports it freely.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+__all__ = [
+    # cost
+    "estimate_flow_waa_cost",
+    "FlowRunCostEstimate",
+    "SpendLedger",
+    "CostGuardConfig",
+    "MODELS",
+    # replay runner
+    "FlowTask",
+    "PerTaskReplayMetrics",
+    "run_demonstrate_then_replay",
+    "aggregate_replay_metrics",
+    # hybrid agent
+    "HybridFlowAgent",
+]
+
+_EXPORTS = {
+    "estimate_flow_waa_cost": ("openadapt_evals.flow.cost", "estimate_flow_waa_cost"),
+    "FlowRunCostEstimate": ("openadapt_evals.flow.cost", "FlowRunCostEstimate"),
+    "SpendLedger": ("openadapt_evals.flow.cost", "SpendLedger"),
+    "CostGuardConfig": ("openadapt_evals.flow.cost", "CostGuardConfig"),
+    "MODELS": ("openadapt_evals.flow.cost", "MODELS"),
+    "FlowTask": ("openadapt_evals.flow.replay_runner", "FlowTask"),
+    "PerTaskReplayMetrics": ("openadapt_evals.flow.replay_runner", "PerTaskReplayMetrics"),
+    "run_demonstrate_then_replay": (
+        "openadapt_evals.flow.replay_runner",
+        "run_demonstrate_then_replay",
+    ),
+    "aggregate_replay_metrics": (
+        "openadapt_evals.flow.replay_runner",
+        "aggregate_replay_metrics",
+    ),
+    "HybridFlowAgent": ("openadapt_evals.flow.hybrid_agent", "HybridFlowAgent"),
+}
+
+if TYPE_CHECKING:  # pragma: no cover
+    from openadapt_evals.flow.cost import (
+        CostGuardConfig,
+        FlowRunCostEstimate,
+        MODELS,
+        SpendLedger,
+        estimate_flow_waa_cost,
+    )
+    from openadapt_evals.flow.hybrid_agent import HybridFlowAgent
+    from openadapt_evals.flow.replay_runner import (
+        FlowTask,
+        PerTaskReplayMetrics,
+        aggregate_replay_metrics,
+        run_demonstrate_then_replay,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    target = _EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module = importlib.import_module(target[0])
+    return getattr(module, target[1])
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/openadapt_evals/flow/cost.py
+++ b/openadapt_evals/flow/cost.py
@@ -1,0 +1,373 @@
+"""Cost model + hard guardrails for evaluating openadapt-flow on WAA.
+
+This module is **stdlib-only** (``math``, ``dataclasses``) and imports nothing
+from ``openadapt_flow`` or any heavy dependency, so it is safe to import in
+light CI and to drive the ``--dry-run`` cost estimate without a VM, an API
+key, or the ``flow`` extra installed.
+
+Two responsibilities:
+
+1. **Cost estimation** (:func:`estimate_flow_waa_cost`) -- dollars for a run of
+   ``N`` WAA tasks in either eval mode:
+
+   - ``replay`` (demonstrate-then-replay): the compiled bundle replays with
+     ~0 model calls, so the *only* cost is Azure VM-hours. Token cost ~= $0.
+   - ``hybrid`` (compiled-first, agent-fallback-on-halt): the compiled arm is
+     free; only the fraction of tasks that *halt* pay for a computer-use agent
+     to finish, and each fallback starts mid-workflow so it runs fewer steps
+     than a from-scratch agent. Azure VM-hours apply to all tasks.
+
+   A pure-agent baseline cost (every task, every step, paid) is computed too so
+   the compiled/hybrid-vs-agent ratio is visible.
+
+2. **Hard guardrails** (:class:`SpendLedger`) -- mirrors openadapt-flow's
+   benchmark ``SpendLedger``: a per-run $ cap, a hard total $ ceiling, a
+   per-task token cap, and abort-on-repeated-billing-error. There was a prior
+   $40-70 uncapped-run incident; these caps are mandatory for any paid run.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+# ---------------------------------------------------------------------------
+# Vision-model pricing (list price, February 2026). Sources:
+#   OpenAI:    https://platform.openai.com/docs/pricing
+#   Anthropic: https://platform.claude.com/docs/en/about-claude/pricing
+# ---------------------------------------------------------------------------
+
+
+def openai_image_tokens(width: int, height: int, detail: str = "high") -> int:
+    """OpenAI GPT-4o image tokens: 85 + 170*tiles over 512px tiles at <=768 short side."""
+    if detail == "low":
+        return 85
+    max_dim = 2048
+    if width > max_dim or height > max_dim:
+        scale = max_dim / max(width, height)
+        width = int(width * scale)
+        height = int(height * scale)
+    short_side = min(width, height)
+    if short_side > 768:
+        scale = 768 / short_side
+        width = int(width * scale)
+        height = int(height * scale)
+    tiles = math.ceil(width / 512) * math.ceil(height / 512)
+    return 85 + (170 * tiles)
+
+
+def claude_image_tokens(width: int, height: int) -> int:
+    """Claude image tokens: (W*H)/750, resized so the long edge is <=1568px."""
+    long_edge = max(width, height)
+    if long_edge > 1568:
+        scale = 1568 / long_edge
+        width = int(width * scale)
+        height = int(height * scale)
+    return int((width * height) / 750)
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    """List-price pricing for one vision model."""
+
+    name: str
+    input_per_million: float
+    output_per_million: float
+    image_token_calculator: Callable[[int, int], int]
+    notes: str = ""
+
+
+MODELS: dict[str, ModelPricing] = {
+    "gpt-4o": ModelPricing("GPT-4o", 2.50, 10.00, openai_image_tokens),
+    "gpt-4o-mini": ModelPricing("GPT-4o-mini", 0.15, 0.60, openai_image_tokens),
+    "claude-sonnet-4": ModelPricing(
+        "Claude Sonnet 4", 3.00, 15.00, claude_image_tokens, "Balanced cost/capability."
+    ),
+    "claude-opus-4.5": ModelPricing(
+        "Claude Opus 4.5", 15.00, 75.00, claude_image_tokens, "Most capable, highest cost."
+    ),
+    "claude-haiku-4.5": ModelPricing(
+        "Claude Haiku 4.5", 1.00, 5.00, claude_image_tokens, "Cheapest Claude model."
+    ),
+}
+
+DEFAULT_MODEL = "claude-sonnet-4"
+
+# ---------------------------------------------------------------------------
+# WAA run parameters (defaults; all overridable).
+# ---------------------------------------------------------------------------
+
+#: Azure VM $/hour. The existing ``estimate_cost`` default (D4_v3, East US).
+#: AWS m8i.2xlarge (nested-virt) is ~$0.46/hr -- pass that via ``vm_hourly``.
+DEFAULT_VM_HOURLY = 0.19
+
+#: WAA screenshot resolution.
+DEFAULT_SCREEN = (1920, 1080)
+
+#: Average steps a from-scratch agent takes per WAA task (WAA paper: 15-30).
+DEFAULT_AGENT_STEPS_PER_TASK = 22
+
+#: A hybrid fallback starts mid-workflow (after the compiled prefix ran), so it
+#: needs fewer steps than a from-scratch agent.
+DEFAULT_FALLBACK_STEPS = 10
+
+#: Text tokens (task instruction + a11y context) and output tokens per step.
+DEFAULT_TEXT_TOKENS_PER_STEP = 500
+DEFAULT_OUTPUT_TOKENS_PER_STEP = 300
+
+#: Per-task minutes on the VM. Replay is deterministic + model-free (fast);
+#: an agent fallback is slower.
+DEFAULT_REPLAY_MINUTES_PER_TASK = 1.0
+DEFAULT_AGENT_MINUTES_PER_TASK = 3.0
+
+#: Provisioning/cleanup overhead added once to the whole run (~15 min).
+DEFAULT_OVERHEAD_HOURS = 0.25
+
+
+def tokens_per_step(
+    model: ModelPricing,
+    screen: tuple[int, int] = DEFAULT_SCREEN,
+    text_tokens: int = DEFAULT_TEXT_TOKENS_PER_STEP,
+    output_tokens: int = DEFAULT_OUTPUT_TOKENS_PER_STEP,
+) -> tuple[int, int]:
+    """Return (input_tokens, output_tokens) for one agent step (image + text)."""
+    image_tokens = model.image_token_calculator(*screen)
+    return image_tokens + text_tokens, output_tokens
+
+
+def cost_per_step_usd(model: ModelPricing, **kw) -> float:
+    """List-price $ for one agent step (one screenshot + reasoning + action)."""
+    in_tokens, out_tokens = tokens_per_step(model, **kw)
+    return (in_tokens / 1_000_000) * model.input_per_million + (
+        out_tokens / 1_000_000
+    ) * model.output_per_million
+
+
+# ---------------------------------------------------------------------------
+# Full-run estimate.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FlowRunCostEstimate:
+    """Estimated cost breakdown for a flow-on-WAA run of ``num_tasks`` tasks."""
+
+    mode: str
+    num_tasks: int
+    model_name: str
+    vm_hourly: float
+    vm_hours: float
+    vm_cost_usd: float
+    fallback_rate: float
+    paid_tasks: float
+    agent_steps_per_paid_task: int
+    token_cost_usd: float
+    total_cost_usd: float
+    cost_per_task_usd: float
+    baseline_agent_cost_usd: float
+    baseline_agent_steps_per_task: int
+
+    def as_dict(self) -> dict:
+        return {
+            "mode": self.mode,
+            "num_tasks": self.num_tasks,
+            "model": self.model_name,
+            "vm_hourly_usd": round(self.vm_hourly, 4),
+            "vm_hours": round(self.vm_hours, 3),
+            "vm_cost_usd": round(self.vm_cost_usd, 4),
+            "fallback_rate": round(self.fallback_rate, 3),
+            "paid_tasks": round(self.paid_tasks, 2),
+            "agent_steps_per_paid_task": self.agent_steps_per_paid_task,
+            "token_cost_usd": round(self.token_cost_usd, 4),
+            "total_cost_usd": round(self.total_cost_usd, 4),
+            "cost_per_task_usd": round(self.cost_per_task_usd, 5),
+            "baseline_pure_agent_cost_usd": round(self.baseline_agent_cost_usd, 4),
+            "baseline_agent_steps_per_task": self.baseline_agent_steps_per_task,
+            "savings_vs_baseline_usd": round(
+                self.baseline_agent_cost_usd - self.total_cost_usd, 4
+            ),
+        }
+
+
+def estimate_flow_waa_cost(
+    num_tasks: int,
+    mode: str = "replay",
+    model_name: str = DEFAULT_MODEL,
+    *,
+    fallback_rate: float = 0.30,
+    vm_hourly: float = DEFAULT_VM_HOURLY,
+    screen: tuple[int, int] = DEFAULT_SCREEN,
+    agent_steps_per_task: int = DEFAULT_AGENT_STEPS_PER_TASK,
+    fallback_steps: int = DEFAULT_FALLBACK_STEPS,
+    replay_minutes_per_task: float = DEFAULT_REPLAY_MINUTES_PER_TASK,
+    agent_minutes_per_task: float = DEFAULT_AGENT_MINUTES_PER_TASK,
+    overhead_hours: float = DEFAULT_OVERHEAD_HOURS,
+    num_workers: int = 1,
+) -> FlowRunCostEstimate:
+    """Estimate the dollar cost of a flow-on-WAA run.
+
+    Args:
+        num_tasks: Number of WAA tasks in the run.
+        mode: ``"replay"`` (demonstrate-then-replay, ~0 model calls) or
+            ``"hybrid"`` (compiled-first, agent-fallback-on-halt).
+        model_name: Key into :data:`MODELS` for the (fallback) agent arm.
+        fallback_rate: Fraction of tasks expected to halt and invoke the paid
+            fallback agent (hybrid only; ignored for replay).
+        vm_hourly: Azure/AWS VM $/hour.
+        num_workers: Parallel VMs (total VM-hours unchanged; kept for reporting).
+
+    Returns:
+        A :class:`FlowRunCostEstimate`.
+    """
+    if model_name not in MODELS:
+        raise ValueError(f"unknown model {model_name!r}; choose from {sorted(MODELS)}")
+    model = MODELS[model_name]
+    step_cost = cost_per_step_usd(model, screen=screen)
+
+    if mode == "replay":
+        paid_tasks = 0.0
+        agent_steps = 0
+        token_cost = 0.0
+        minutes_per_task = replay_minutes_per_task
+        eff_fallback_rate = 0.0
+    elif mode == "hybrid":
+        eff_fallback_rate = max(0.0, min(1.0, fallback_rate))
+        paid_tasks = num_tasks * eff_fallback_rate
+        agent_steps = fallback_steps
+        token_cost = paid_tasks * agent_steps * step_cost
+        minutes_per_task = (
+            (1 - eff_fallback_rate) * replay_minutes_per_task
+            + eff_fallback_rate * agent_minutes_per_task
+        )
+    else:
+        raise ValueError(f"unknown mode {mode!r}; expected 'replay' or 'hybrid'")
+
+    wall_minutes = (num_tasks * minutes_per_task) / max(1, num_workers)
+    vm_hours = (wall_minutes / 60 + overhead_hours) * max(1, num_workers)
+    vm_cost = vm_hours * vm_hourly
+    total = vm_cost + token_cost
+    baseline_cost = num_tasks * agent_steps_per_task * step_cost
+
+    return FlowRunCostEstimate(
+        mode=mode,
+        num_tasks=num_tasks,
+        model_name=model.name,
+        vm_hourly=vm_hourly,
+        vm_hours=vm_hours,
+        vm_cost_usd=vm_cost,
+        fallback_rate=eff_fallback_rate,
+        paid_tasks=paid_tasks,
+        agent_steps_per_paid_task=agent_steps,
+        token_cost_usd=token_cost,
+        total_cost_usd=total,
+        cost_per_task_usd=(total / num_tasks if num_tasks else 0.0),
+        baseline_agent_cost_usd=baseline_cost,
+        baseline_agent_steps_per_task=agent_steps_per_task,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hard guardrails (mirrors openadapt_flow.benchmark.hybrid_benchmark.SpendLedger).
+# ---------------------------------------------------------------------------
+
+#: Consecutive auth/billing-looking failures after which paid spending aborts.
+BILLING_ABORT_AFTER = 2
+
+_BILLING_ERROR_MARKERS = (
+    "billing",
+    "quota",
+    "insufficient_quota",
+    "insufficient funds",
+    "payment",
+    "credit",
+    "rate_limit",
+    "rate limit",
+    "401",
+    "403",
+    "429",
+    "unauthorized",
+    "authentication",
+    "invalid api key",
+    "invalid_api_key",
+    "permission",
+)
+
+
+def looks_like_billing_error(error: str) -> bool:
+    """True when an error string looks like an auth/billing/quota failure."""
+    low = error.lower()
+    return any(marker in low for marker in _BILLING_ERROR_MARKERS)
+
+
+@dataclass
+class CostGuardConfig:
+    """Hard cost guardrails for a paid run. All caps are list-price dollars."""
+
+    per_run_usd: float = 0.50
+    total_usd: float = 5.00
+    per_task_tokens: int = 60_000
+    billing_abort_after: int = BILLING_ABORT_AFTER
+
+
+class SpendLedger:
+    """One budget across all paid runs, with hard caps and billing-abort.
+
+    Enforces the total ceiling BEFORE each paid run (a run may not start unless
+    its full per-run cap still fits under the ceiling), caps per-task tokens,
+    and aborts all further paid spending after ``billing_abort_after``
+    consecutive auth/billing-looking failures.
+    """
+
+    def __init__(self, config: Optional[CostGuardConfig] = None) -> None:
+        self.config = config or CostGuardConfig()
+        self.spent = 0.0
+        self.tokens_used = 0
+        self.aborted: Optional[str] = None
+        self._consecutive_billing_errors = 0
+
+    def can_start(self) -> bool:
+        """True when a new paid run may start under the ceiling."""
+        return (
+            self.aborted is None
+            and self.spent + self.config.per_run_usd <= self.config.total_usd
+        )
+
+    def blocked_reason(self) -> str:
+        """Why a paid run may not start right now."""
+        if self.aborted is not None:
+            return self.aborted
+        return (
+            f"total budget ceiling: ${self.spent:.2f} of ${self.config.total_usd:.2f} "
+            f"spent; the next run's ${self.config.per_run_usd:.2f} cap could exceed it"
+        )
+
+    def token_cap_exceeded(self, tokens: int) -> bool:
+        """True when a single task's token count exceeds the per-task cap."""
+        return tokens > self.config.per_task_tokens
+
+    def record(
+        self, cost_usd: float, *, tokens: int = 0, error: Optional[str] = None
+    ) -> None:
+        """Record a finished paid run's cost, token usage, and error status."""
+        self.spent += cost_usd
+        self.tokens_used += tokens
+        if error and looks_like_billing_error(error):
+            self._consecutive_billing_errors += 1
+            if self._consecutive_billing_errors >= self.config.billing_abort_after:
+                self.aborted = (
+                    f"paid spending aborted after {self._consecutive_billing_errors} "
+                    f"consecutive auth/billing errors -- last error: {error}"
+                )
+        else:
+            self._consecutive_billing_errors = 0
+
+    def summary(self) -> dict:
+        return {
+            "spent_usd": round(self.spent, 4),
+            "tokens_used": self.tokens_used,
+            "per_run_cap_usd": self.config.per_run_usd,
+            "total_cap_usd": self.config.total_usd,
+            "per_task_token_cap": self.config.per_task_tokens,
+            "aborted": self.aborted,
+        }

--- a/openadapt_evals/flow/hybrid_agent.py
+++ b/openadapt_evals/flow/hybrid_agent.py
@@ -187,7 +187,11 @@ class HybridFlowAgent(BenchmarkAgent):
 
         self._fallback_mode = True
         self.metrics.update({"fallback_used": True, "halt_terminal_outcome": terminal})
-        return self._fallback_step(observation, task, history)
+        # The observation handed to this first act() predates the replay's VM
+        # mutations (the replay drove the WAA server directly, bypassing the
+        # adapter). Prime a fresh post-replay screenshot with a no-op WAIT so the
+        # runner fetches current state before the paid agent's first real step.
+        return BenchmarkAction(type="wait")
 
     def _fallback_step(self, observation, task, history) -> BenchmarkAction:
         # Per-task token cap: stop the fallback if it blows the budget.

--- a/openadapt_evals/flow/hybrid_agent.py
+++ b/openadapt_evals/flow/hybrid_agent.py
@@ -1,0 +1,221 @@
+"""Hybrid-as-agent adapter: compiled replay first, computer-use agent fallback
+on a detected halt.
+
+:class:`HybridFlowAgent` implements the ``BenchmarkAgent`` interface so the
+existing WAA runner (``evaluate_agent_on_benchmark``) can drive it exactly like
+any other agent -- which makes it **directly comparable to a pure agent
+baseline on the same tasks, scored by the same WAA verifier**.
+
+Behaviour (mirrors openadapt-flow's hybrid benchmark, arm D):
+
+- On the first ``act`` of an episode it runs the compiled bundle end-to-end via
+  :class:`openadapt_flow.backends.windows_backend.WindowsBackend` against the
+  WAA in-guest server. This is the compiled arm: ~0 model calls, $0.
+- If the replay completes, it returns ``done`` (WAA's verifier / the runner's
+  done-gate confirms real success -- never self-report).
+- If the replay **halts**, it hands the SAME live VM to the wrapped
+  computer-use agent for the remaining steps, but only if the shared
+  :class:`~openadapt_evals.flow.cost.SpendLedger` allows a paid run. Otherwise
+  the halt is surfaced as an error with the skip reason disclosed.
+
+Heavy imports (``openadapt_flow``) are lazy and the replay step is injectable,
+so this is unit-testable with a fake replay + a scripted base agent -- no VM,
+no ``flow`` extra, no $.
+"""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+from openadapt_evals.adapters.base import (
+    BenchmarkAction,
+    BenchmarkObservation,
+    BenchmarkTask,
+)
+from openadapt_evals.agents.base import BenchmarkAgent
+from openadapt_evals.flow.cost import CostGuardConfig, SpendLedger
+from openadapt_evals.flow.replay_runner import ReplayFn, _default_replay_fn
+
+logger = logging.getLogger(__name__)
+
+
+def _step_cost_from_logs(logs: Optional[dict]) -> tuple[float, int]:
+    """Best-effort (cost_usd, tokens) from an agent's ``_last_step_logs``."""
+    if not isinstance(logs, dict):
+        return 0.0, 0
+    cost = float(logs.get("cost_usd", logs.get("cost", 0.0)) or 0.0)
+    tokens = int(
+        logs.get("total_tokens")
+        or (int(logs.get("input_tokens", 0) or 0) + int(logs.get("output_tokens", 0) or 0))
+        or 0
+    )
+    return cost, tokens
+
+
+class HybridFlowAgent(BenchmarkAgent):
+    """Compiled-replay-first, agent-fallback-on-halt, as a ``BenchmarkAgent``.
+
+    Args:
+        base_agent: The computer-use agent used only on a compiled halt (the
+            paid fallback arm) -- e.g. a ``PlannerGrounderAgent`` or
+            ``ClaudeComputerUseAgent``. The pure-agent baseline is this same
+            agent run alone on the same tasks.
+        bundle_dir: Compiled openadapt-flow bundle for the task.
+        server_url: WAA in-guest Flask server URL (the compiled arm drives it
+            directly -- the same server the WAALiveAdapter uses).
+        ledger: Shared paid-spend guardrail. Created from ``guard_config`` when
+            omitted.
+        guard_config: Guardrails used to build a ledger when ``ledger`` is None.
+        replay_fn: Override the compiled replay (defaults to a real
+            WindowsBackend replay; inject a fake for tests).
+        params: Parameter substitutions forwarded to the replay.
+    """
+
+    def __init__(
+        self,
+        base_agent: BenchmarkAgent,
+        bundle_dir: Path | str,
+        server_url: str,
+        *,
+        ledger: Optional[SpendLedger] = None,
+        guard_config: Optional[CostGuardConfig] = None,
+        replay_fn: Optional[ReplayFn] = None,
+        params: Optional[dict[str, str]] = None,
+    ) -> None:
+        self.base_agent = base_agent
+        self.bundle_dir = Path(bundle_dir)
+        self.server_url = server_url
+        self.ledger = ledger or SpendLedger(guard_config)
+        self.replay_fn: ReplayFn = replay_fn or _default_replay_fn
+        self.params = params or {}
+        self._last_step_logs: Optional[dict] = None
+        self._reset_episode_state()
+
+    def _reset_episode_state(self) -> None:
+        self._replay_done = False
+        self._fallback_mode = False
+        self._episode_recorded = True  # nothing pending yet
+        self._fallback_cost_usd = 0.0
+        self._fallback_tokens = 0
+        self._fallback_steps = 0
+        self.metrics: dict[str, Any] = {}
+
+    def reset(self) -> None:
+        """Reset for a new episode; record the previous episode's paid spend."""
+        self.finalize_episode()
+        self.base_agent.reset()
+        self._last_step_logs = None
+        self._reset_episode_state()
+
+    def finalize_episode(self) -> None:
+        """Record the just-finished episode's fallback spend to the ledger once."""
+        if getattr(self, "_episode_recorded", True):
+            return
+        error = self.metrics.get("fallback_error")
+        self.ledger.record(
+            self._fallback_cost_usd, tokens=self._fallback_tokens, error=error
+        )
+        self._episode_recorded = True
+
+    # -- BenchmarkAgent -----------------------------------------------------
+
+    def act(
+        self,
+        observation: BenchmarkObservation,
+        task: BenchmarkTask,
+        history: Optional[list[tuple[BenchmarkObservation, BenchmarkAction]]] = None,
+    ) -> BenchmarkAction:
+        if not self._replay_done:
+            return self._run_compiled_then_maybe_fallback(observation, task, history)
+        if self._fallback_mode:
+            return self._fallback_step(observation, task, history)
+        # Compiled arm already declared done; nothing more to do.
+        return BenchmarkAction(type="done")
+
+    # -- internals ----------------------------------------------------------
+
+    def _run_compiled_then_maybe_fallback(
+        self, observation, task, history
+    ) -> BenchmarkAction:
+        self._replay_done = True
+        self._episode_recorded = False  # an episode is now in progress
+        run_dir = Path(tempfile.mkdtemp(prefix=f"hybrid_{task.task_id}_"))
+        reported_success = False
+        halted = True
+        terminal = None
+        try:
+            report = self.replay_fn(self.bundle_dir, self.server_url, run_dir, self.params)
+            reported_success = bool(getattr(report, "success", False))
+            terminal = getattr(report, "terminal_outcome", None)
+            halted = terminal == "halt" or (not reported_success and terminal != "success")
+            self.metrics.update(
+                {
+                    "compiled_reported_success": reported_success,
+                    "compiled_terminal_outcome": terminal,
+                    "compiled_model_calls": int(getattr(report, "model_calls", 0) or 0),
+                    "compiled_heal_count": int(getattr(report, "heal_count", 0) or 0),
+                    "compiled_rung_counts": dict(getattr(report, "rung_counts", {}) or {}),
+                    "compiled_est_cost_usd": float(
+                        getattr(report, "est_model_cost_usd", 0.0) or 0.0
+                    ),
+                }
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning("compiled replay raised for %s: %s", task.task_id, e)
+            self.metrics["compiled_error"] = str(e)
+            reported_success = False
+            halted = True
+
+        if reported_success and not halted:
+            self.metrics["fallback_used"] = False
+            return BenchmarkAction(type="done")
+
+        # Compiled arm halted -> consider the paid fallback under the ledger.
+        if not self.ledger.can_start():
+            reason = self.ledger.blocked_reason()
+            self.metrics.update({"fallback_used": False, "fallback_blocked_reason": reason})
+            return BenchmarkAction(
+                type="error",
+                raw_action={
+                    "error_type": "agent",
+                    "reason": f"compiled replay halted; paid fallback blocked: {reason}",
+                },
+            )
+
+        self._fallback_mode = True
+        self.metrics.update({"fallback_used": True, "halt_terminal_outcome": terminal})
+        return self._fallback_step(observation, task, history)
+
+    def _fallback_step(self, observation, task, history) -> BenchmarkAction:
+        # Per-task token cap: stop the fallback if it blows the budget.
+        if self.ledger.token_cap_exceeded(self._fallback_tokens):
+            self.metrics["fallback_error"] = (
+                f"per-task token cap exceeded ({self._fallback_tokens} > "
+                f"{self.ledger.config.per_task_tokens})"
+            )
+            return BenchmarkAction(
+                type="error",
+                raw_action={
+                    "error_type": "agent",
+                    "reason": self.metrics["fallback_error"],
+                },
+            )
+
+        action = self.base_agent.act(observation, task, history)
+        self._fallback_steps += 1
+        logs = getattr(self.base_agent, "_last_step_logs", None)
+        self._last_step_logs = logs
+        cost, tokens = _step_cost_from_logs(logs)
+        self._fallback_cost_usd += cost
+        self._fallback_tokens += tokens
+        self.metrics.update(
+            {
+                "fallback_steps": self._fallback_steps,
+                "fallback_cost_usd": round(self._fallback_cost_usd, 5),
+                "fallback_tokens": self._fallback_tokens,
+            }
+        )
+        return action

--- a/openadapt_evals/flow/parallels_env.py
+++ b/openadapt_evals/flow/parallels_env.py
@@ -1,0 +1,320 @@
+"""Parallels local-VM environment for the flow-on-WAA harness.
+
+Runs the SAME demonstrate-then-replay + hybrid eval modes LOCALLY at **$0**
+against a Parallels Windows VM (native Apple-Silicon virt) -- so we can de-risk
+the runner + backend + replay on a real local Windows desktop BEFORE spending
+Azure $ on the WAA (cloud) environment. Same runner, same per-task metrics.
+
+Reuses openadapt-flow's :class:`openadapt_flow.backends.parallels_vm.ParallelsVM`
+(a ``prlctl`` wrapper: snapshot/revert-safe, host-side capture, in-session
+``win_agent`` launch via ``launch_agent``) and the ``win_agent`` server from
+openadapt-flow PR #95. Once ``launch_agent`` is up it exposes the SAME
+``/screenshot`` + ``/execute_windows`` contract WAA does, so the identical
+``WindowsBackend`` replay path works unchanged.
+
+Parallels supplies the ENVIRONMENT (a real local Windows desktop) but NOT WAA's
+standardized tasks/verifiers -- those are supplied here: trivial built-in tasks
+on Notepad/Calculator, verified by reading ground-truth in-guest state (mirrors
+how WAA verifies real OS state, just with our own checks).
+
+Environments at a glance:
+    Parallels  -> LOCAL,  $0 (native virt), this module.
+    WAA/Azure  -> CLOUD,  $  (VM-hours + agent tokens), replay_runner + cost.
+
+Snapshot safety: **snapshot -> run -> revert**. We take our OWN snapshot of the
+clean state, run the (mutating) task, then ``revert`` to it. We NEVER stop or
+delete the user's VM or their snapshots -- ``ParallelsVM`` exposes no delete, so
+the contract is revert-only by construction.
+
+Opt-in: everything here is SKIPPED unless ``OPENADAPT_PARALLELS=1`` (or
+``ParallelsConfig(enabled=True)``). Heavy imports (``openadapt_flow``) are lazy
+and the VM is injectable, so this is unit-testable with a fake VM -- no prlctl,
+no real VM, no mutation.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+from openadapt_evals.flow.replay_runner import (
+    FlowTask,
+    PerTaskReplayMetrics,
+    aggregate_replay_metrics,
+    run_demonstrate_then_replay,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Opt-in gate. Nothing here runs against a real VM unless this is truthy.
+PARALLELS_ENV_VAR = "OPENADAPT_PARALLELS"
+
+#: The user's suspended Parallels "Windows 11" VM (from project memory). Only a
+#: default -- override via ``OPENADAPT_PARALLELS_VM_UUID`` or ``ParallelsConfig``.
+DEFAULT_VM_UUID = "d4f9c29a-52e1-4793-9334-7e971c3d0ab3"
+
+#: win_agent port (ParallelsVM.SHIM_PORT default).
+DEFAULT_AGENT_PORT = 5000
+
+# A verifier: (vm) -> (success, reason). Reads ground-truth in-guest state.
+VerifyFn = Callable[[Any], "tuple[bool, Optional[str]]"]
+
+
+def parallels_enabled(config: "Optional[ParallelsConfig]" = None) -> bool:
+    """True when the Parallels environment is opted in (env var or config)."""
+    if config is not None and config.enabled:
+        return True
+    return os.environ.get(PARALLELS_ENV_VAR, "").strip().lower() in {"1", "true", "yes"}
+
+
+@dataclass
+class ParallelsConfig:
+    """Configuration for a Parallels local-VM eval session."""
+
+    vm_uuid: str = field(
+        default_factory=lambda: os.environ.get("OPENADAPT_PARALLELS_VM_UUID", DEFAULT_VM_UUID)
+    )
+    prlctl: str = "/usr/local/bin/prlctl"
+    agent_port: int = DEFAULT_AGENT_PORT
+    agent_token: str = field(default_factory=lambda: secrets.token_hex(16))
+    snapshot_name: str = ""  # filled in at session start if empty
+    settle_s: float = 6.0
+    launch_wait_s: float = 25.0
+    enabled: bool = False  # explicit override of the env-var gate
+
+
+@dataclass
+class ParallelsTask:
+    """A trivial local task: a demo bundle to replay + OUR ground-truth verifier."""
+
+    task_id: str
+    instruction: str
+    verify: VerifyFn
+    bundle_dir: Optional[Path] = None
+    params: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Built-in trivial tasks + ground-truth verifiers (in-guest state reads).
+# ---------------------------------------------------------------------------
+
+_NOTEPAD_OUT = r"C:\oa\eval\notepad_out.txt"
+_NOTEPAD_EXPECTED = "openadapt-flow replay ok"
+
+
+def verify_notepad_file(
+    vm: Any, *, path: str = _NOTEPAD_OUT, expected: str = _NOTEPAD_EXPECTED
+) -> "tuple[bool, Optional[str]]":
+    """Success iff the Notepad task wrote ``expected`` into ``path`` in-guest."""
+    ps = f"if (Test-Path '{path}') {{ Get-Content -Raw '{path}' }} else {{ 'MISSING' }}"
+    proc = vm.exec_ps(ps)
+    out = (getattr(proc, "stdout", "") or "").strip()
+    ok = expected in out
+    return ok, f"notepad file contents: {out!r}"
+
+
+def verify_calculator_open(vm: Any) -> "tuple[bool, Optional[str]]":
+    """Success iff a Calculator window/process is present in-guest (trivial check)."""
+    proc = vm.exec_cmd('tasklist /FI "IMAGENAME eq CalculatorApp.exe" /FI "IMAGENAME eq Calculator.exe"')
+    out = (getattr(proc, "stdout", "") or "")
+    ok = "alculator" in out
+    return ok, f"tasklist: {out.strip()[:120]!r}"
+
+
+def builtin_tasks(bundles_dir: Optional[Path] = None) -> list[ParallelsTask]:
+    """Return the built-in trivial local tasks.
+
+    A task's ``bundle_dir`` is ``<bundles_dir>/<task_id>`` when that directory
+    holds a compiled ``workflow.json`` (record + compile the demo first, same as
+    WAA); otherwise it stays None and the runner flags "no compiled bundle".
+    """
+
+    def _bundle(task_id: str) -> Optional[Path]:
+        if bundles_dir is None:
+            return None
+        cand = Path(bundles_dir) / task_id
+        return cand if (cand / "workflow.json").exists() else None
+
+    specs = [
+        ("notepad_write", "Open Notepad, type a line, and save it to a file.",
+         verify_notepad_file),
+        ("calculator_open", "Open the Calculator app.", verify_calculator_open),
+    ]
+    return [
+        ParallelsTask(task_id=tid, instruction=instr, verify=vfn, bundle_dir=_bundle(tid))
+        for tid, instr, vfn in specs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Session: snapshot -> run -> revert, launch win_agent, expose the replay path.
+# ---------------------------------------------------------------------------
+
+
+class ParallelsSession:
+    """A snapshot-safe, opt-in-gated Parallels eval session.
+
+    Lifecycle (``with`` block):
+      enter  -> ensure VM running, snapshot the clean state, launch win_agent
+                (session 1) and return its URL as :attr:`server_url`.
+      body   -> replay/hybrid drive the SAME WindowsBackend against that URL.
+      exit   -> revert to the entry snapshot (clean reset). NEVER stop/delete.
+
+    Args:
+        config: Session configuration.
+        vm: An injected ``ParallelsVM``-like object (for tests). When None, a
+            real ``openadapt_flow.backends.parallels_vm.ParallelsVM`` is built
+            lazily (requires the ``flow`` extra + prlctl + the VM).
+    """
+
+    def __init__(self, config: Optional[ParallelsConfig] = None, *, vm: Any = None) -> None:
+        self.config = config or ParallelsConfig()
+        self._vm = vm
+        self._snapshot_id: Optional[str] = None
+        self.server_url: Optional[str] = None
+
+    @property
+    def vm(self) -> Any:
+        if self._vm is None:
+            raise RuntimeError("ParallelsSession not entered (no VM)")
+        return self._vm
+
+    def _build_vm(self) -> Any:
+        try:
+            from openadapt_flow.backends.parallels_vm import ParallelsVM
+        except ImportError as e:  # pragma: no cover - only without the extra/PR95
+            raise ImportError(
+                "openadapt-flow (with the win_agent/ParallelsVM support from PR #95) "
+                "is required for the Parallels environment. Install: "
+                "pip install 'openadapt-evals[flow]'"
+            ) from e
+        return ParallelsVM(self.config.vm_uuid, prlctl=self.config.prlctl)
+
+    def __enter__(self) -> "ParallelsSession":
+        if not parallels_enabled(self.config):
+            raise RuntimeError(
+                f"Parallels environment is opt-in: set {PARALLELS_ENV_VAR}=1 "
+                "(or ParallelsConfig(enabled=True)) to run it."
+            )
+        if self._vm is None:
+            self._vm = self._build_vm()
+        vm = self._vm
+
+        vm.ensure_running(settle_s=self.config.settle_s)
+        name = self.config.snapshot_name or f"oa-flow-eval-{int(time.time())}"
+        # snapshot -> run -> revert: snapshot the CURRENT (clean) state now.
+        self._snapshot_id = vm.snapshot(name, "openadapt-flow eval clean state (revert-only)")
+        logger.info("Parallels: snapshotted clean state as %s (%s)", name, self._snapshot_id)
+
+        self.server_url = vm.launch_agent(
+            port=self.config.agent_port,
+            host="0.0.0.0",
+            token=self.config.agent_token,
+            wait_s=self.config.launch_wait_s,
+        )
+        logger.info("Parallels: win_agent up at %s", self.server_url)
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        vm = self._vm
+        if vm is not None and self._snapshot_id is not None:
+            # Clean per-run reset. Revert-only: we never stop or delete the VM
+            # or any snapshot (the user's VM must survive untouched).
+            try:
+                vm.revert(self._snapshot_id)
+                logger.info("Parallels: reverted to %s (clean reset)", self._snapshot_id)
+            except Exception:  # noqa: BLE001
+                logger.exception("Parallels: revert to %s failed", self._snapshot_id)
+
+    # -- the replay path (same WindowsBackend contract as WAA) --------------
+
+    def replay_fn(
+        self, bundle_dir: Path, server_url: str, run_dir: Path, params: Optional[dict]
+    ) -> Any:
+        """Replay a bundle via WindowsBackend against the win_agent (with token)."""
+        from openadapt_flow.ir import Workflow
+        from openadapt_flow.runtime import Replayer
+
+        backend = self._make_backend(server_url)
+        workflow = Workflow.load(bundle_dir)
+        try:
+            return Replayer(backend).run(
+                workflow, params=params or {}, bundle_dir=bundle_dir, run_dir=run_dir
+            )
+        finally:
+            close = getattr(backend, "close", None)
+            if callable(close):
+                close()
+
+    def _make_backend(self, server_url: str) -> Any:
+        from openadapt_flow.backends.windows_backend import WindowsBackend
+
+        # auth_token is a win_agent/PR #95 addition to WindowsBackend; degrade
+        # gracefully on an older flow that lacks it (unauthenticated agent).
+        try:
+            return WindowsBackend(server_url=server_url, auth_token=self.config.agent_token)
+        except TypeError:
+            logger.warning(
+                "WindowsBackend has no auth_token (pre-PR#95 flow); using unauthenticated agent"
+            )
+            return WindowsBackend(server_url=server_url)
+
+
+def make_parallels_evaluator(
+    vm: Any, tasks_by_id: "dict[str, ParallelsTask]"
+) -> "Callable[[str], tuple[bool, Optional[str]]]":
+    """Build a WAA-style verifier callable over our built-in ground-truth checks."""
+
+    def _evaluate(task_id: str) -> "tuple[bool, Optional[str]]":
+        task = tasks_by_id.get(task_id)
+        if task is None:
+            return False, f"unknown parallels task {task_id!r}"
+        return task.verify(vm)
+
+    return _evaluate
+
+
+def run_parallels_replay(
+    tasks: Optional[Sequence[ParallelsTask]] = None,
+    config: Optional[ParallelsConfig] = None,
+    *,
+    vm: Any = None,
+    replay_fn: Optional[Callable] = None,
+    run_root: Path | str = "parallels_results",
+) -> "tuple[list[PerTaskReplayMetrics], dict]":
+    """Demonstrate-then-replay on the LOCAL Parallels VM, scored by OUR verifiers.
+
+    Same runner + metrics as WAA; only the environment (local $0 vs cloud $) and
+    the verifier (ours vs WAA's) differ. Snapshot-safe and opt-in gated.
+
+    Args:
+        tasks: Local tasks (defaults to :func:`builtin_tasks`).
+        config: Session configuration.
+        vm: Injected ``ParallelsVM``-like object (tests). Real VM built when None.
+        replay_fn: Override the replay step (defaults to the session's real
+            WindowsBackend replay; inject a fake for tests).
+        run_root: Directory for per-task replay dirs.
+
+    Returns:
+        (per-task metrics, aggregate summary).
+    """
+    config = config or ParallelsConfig()
+    tasks = list(tasks) if tasks is not None else builtin_tasks()
+    tasks_by_id = {t.task_id: t for t in tasks}
+
+    with ParallelsSession(config, vm=vm) as sess:
+        flow_tasks = [
+            FlowTask(task_id=t.task_id, bundle_dir=t.bundle_dir, params=t.params)
+            for t in tasks
+        ]
+        evaluator = make_parallels_evaluator(sess.vm, tasks_by_id)
+        metrics = run_demonstrate_then_replay(
+            flow_tasks, sess.server_url or "", run_root,
+            replay_fn=replay_fn or sess.replay_fn, evaluator=evaluator,
+        )
+    return metrics, aggregate_replay_metrics(metrics)

--- a/openadapt_evals/flow/replay_runner.py
+++ b/openadapt_evals/flow/replay_runner.py
@@ -1,0 +1,291 @@
+"""Demonstrate-then-replay runner: the paradigm-correct WAA eval for a
+demonstration compiler.
+
+For each WAA task we:
+
+  (a) obtain ONE demonstration and ``compile`` it into an openadapt-flow bundle
+      (offline, done ahead of time -- see ``scripts/record_waa_demos.py`` to
+      record and ``python -m openadapt_flow compile`` to compile);
+  (b) ``replay`` that bundle via :class:`openadapt_flow.backends.windows_backend.WindowsBackend`
+      pointed at the WAA in-guest Flask server (the SAME ``/screenshot`` +
+      ``/execute_windows`` contract WAA already exposes -- no adapter layer);
+  (c) let **WAA's own task evaluator** score success (NOT the replayer's
+      self-report).
+
+Per-task metrics emitted: WAA-verified success, replay self-report, structural
+rung fire rate, model calls (~0 on a healthy replay), wall-clock, and any
+halt/heal events.
+
+Everything heavy (``openadapt_flow``) is imported lazily inside the default
+callables, and both the replay step and the WAA evaluator are injectable, so
+the whole runner is unit-testable with mocks -- no VM, no ``flow`` extra, no $.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# A replay callable: (bundle_dir, server_url, run_dir, params) -> a RunReport-like
+# object exposing .success, .rung_counts, .heal_count, .model_calls,
+# .est_model_cost_usd, .total_ms, .terminal_outcome, .results.
+ReplayFn = Callable[[Path, str, Path, Optional[dict]], Any]
+
+# A WAA evaluator callable: task_id -> (verified_success, reason).
+EvaluatorFn = Callable[[str], "tuple[bool, Optional[str]]"]
+
+
+@dataclass
+class FlowTask:
+    """One WAA task paired with its compiled openadapt-flow bundle."""
+
+    task_id: str
+    bundle_dir: Optional[Path] = None
+    params: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def has_bundle(self) -> bool:
+        return self.bundle_dir is not None and Path(self.bundle_dir).exists()
+
+
+@dataclass
+class PerTaskReplayMetrics:
+    """Per-task metrics for one demonstrate-then-replay run."""
+
+    task_id: str
+    bundle_dir: Optional[str]
+    # Ground truth (WAA's verifier) vs. the replayer's self-report.
+    waa_verified_success: Optional[bool]
+    replay_reported_success: bool
+    # Structural verification rung usage.
+    structural_rung_counts: dict[str, int]
+    structural_rung_fire_total: int
+    rung_fire_rate: float
+    # Model usage (should be ~0 on a healthy replay).
+    model_calls: int
+    est_model_cost_usd: float
+    # Timing + resilience.
+    wall_clock_s: float
+    heal_count: int
+    halted: bool
+    terminal_outcome: Optional[str]
+    num_steps: int
+    error: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        return {
+            "task_id": self.task_id,
+            "bundle_dir": self.bundle_dir,
+            "waa_verified_success": self.waa_verified_success,
+            "replay_reported_success": self.replay_reported_success,
+            "structural_rung_counts": self.structural_rung_counts,
+            "structural_rung_fire_total": self.structural_rung_fire_total,
+            "rung_fire_rate": round(self.rung_fire_rate, 4),
+            "model_calls": self.model_calls,
+            "est_model_cost_usd": round(self.est_model_cost_usd, 5),
+            "wall_clock_s": round(self.wall_clock_s, 3),
+            "heal_count": self.heal_count,
+            "halted": self.halted,
+            "terminal_outcome": self.terminal_outcome,
+            "num_steps": self.num_steps,
+            "error": self.error,
+        }
+
+
+def _default_replay_fn(
+    bundle_dir: Path, server_url: str, run_dir: Path, params: Optional[dict]
+) -> Any:
+    """Replay a bundle once via the WindowsBackend against the WAA server.
+
+    Imports openadapt-flow lazily. Requires the ``flow`` extra
+    (``pip install 'openadapt-evals[flow]'``) and a reachable WAA server.
+    """
+    try:
+        from openadapt_flow.backends.windows_backend import WindowsBackend
+        from openadapt_flow.ir import Workflow
+        from openadapt_flow.runtime import Replayer
+    except ImportError as e:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "openadapt-flow is required for live replay. Install the extra: "
+            "pip install 'openadapt-evals[flow]'"
+        ) from e
+
+    workflow = Workflow.load(bundle_dir)
+    backend = WindowsBackend(server_url=server_url)
+    try:
+        return Replayer(backend).run(
+            workflow, params=params or {}, bundle_dir=bundle_dir, run_dir=run_dir
+        )
+    finally:
+        close = getattr(backend, "close", None)
+        if callable(close):
+            close()
+
+
+def _report_metrics(task: FlowTask, report: Any, wall_clock_s: float) -> PerTaskReplayMetrics:
+    """Extract per-task structural/heal/model metrics from a RunReport-like object."""
+    rung_counts = dict(getattr(report, "rung_counts", {}) or {})
+    rung_total = sum(rung_counts.values())
+    results = getattr(report, "results", []) or []
+    num_steps = len(results)
+    terminal = getattr(report, "terminal_outcome", None)
+    reported_success = bool(getattr(report, "success", False))
+    halted = terminal == "halt" or (not reported_success and terminal != "success")
+    return PerTaskReplayMetrics(
+        task_id=task.task_id,
+        bundle_dir=str(task.bundle_dir) if task.bundle_dir else None,
+        waa_verified_success=None,
+        replay_reported_success=reported_success,
+        structural_rung_counts=rung_counts,
+        structural_rung_fire_total=rung_total,
+        rung_fire_rate=(rung_total / num_steps if num_steps else 0.0),
+        model_calls=int(getattr(report, "model_calls", 0) or 0),
+        est_model_cost_usd=float(getattr(report, "est_model_cost_usd", 0.0) or 0.0),
+        wall_clock_s=wall_clock_s,
+        heal_count=int(getattr(report, "heal_count", 0) or 0),
+        halted=halted,
+        terminal_outcome=terminal,
+        num_steps=num_steps,
+    )
+
+
+def run_demonstrate_then_replay(
+    tasks: Sequence[FlowTask],
+    server_url: str,
+    run_root: Path | str,
+    *,
+    replay_fn: Optional[ReplayFn] = None,
+    evaluator: Optional[EvaluatorFn] = None,
+    on_task: Optional[Callable[[PerTaskReplayMetrics], None]] = None,
+) -> list[PerTaskReplayMetrics]:
+    """Replay each task's compiled bundle and score it with WAA's verifier.
+
+    Args:
+        tasks: Tasks paired with their compiled bundles. A task without a
+            bundle is recorded as an error (it must be recorded + compiled
+            first) and skipped -- never faked.
+        server_url: WAA in-guest Flask server URL (e.g. ``http://localhost:5001``).
+        run_root: Directory that receives one ``<task_id>/`` replay dir per task.
+        replay_fn: Override the replay step (defaults to a real WindowsBackend
+            replay; inject a fake for tests).
+        evaluator: WAA ground-truth verifier ``task_id -> (success, reason)``.
+            When None, ``waa_verified_success`` stays None (replay ran but was
+            not independently scored).
+        on_task: Optional per-task callback.
+
+    Returns:
+        One :class:`PerTaskReplayMetrics` per task, in input order.
+    """
+    replay_fn = replay_fn or _default_replay_fn
+    root = Path(run_root)
+    root.mkdir(parents=True, exist_ok=True)
+    out: list[PerTaskReplayMetrics] = []
+
+    for task in tasks:
+        if not task.has_bundle:
+            metrics = PerTaskReplayMetrics(
+                task_id=task.task_id,
+                bundle_dir=str(task.bundle_dir) if task.bundle_dir else None,
+                waa_verified_success=None,
+                replay_reported_success=False,
+                structural_rung_counts={},
+                structural_rung_fire_total=0,
+                rung_fire_rate=0.0,
+                model_calls=0,
+                est_model_cost_usd=0.0,
+                wall_clock_s=0.0,
+                heal_count=0,
+                halted=False,
+                terminal_outcome=None,
+                num_steps=0,
+                error=(
+                    "no compiled bundle -- record a demo (scripts/record_waa_demos.py) "
+                    "and compile it (python -m openadapt_flow compile) first"
+                ),
+            )
+            out.append(metrics)
+            if on_task:
+                on_task(metrics)
+            continue
+
+        run_dir = root / task.task_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        start = time.monotonic()
+        try:
+            report = replay_fn(Path(task.bundle_dir), server_url, run_dir, task.params)
+            wall = time.monotonic() - start
+            metrics = _report_metrics(task, report, wall)
+        except Exception as e:  # noqa: BLE001 - one bad task must not abort the run
+            logger.exception("replay failed for %s", task.task_id)
+            metrics = PerTaskReplayMetrics(
+                task_id=task.task_id,
+                bundle_dir=str(task.bundle_dir),
+                waa_verified_success=None,
+                replay_reported_success=False,
+                structural_rung_counts={},
+                structural_rung_fire_total=0,
+                rung_fire_rate=0.0,
+                model_calls=0,
+                est_model_cost_usd=0.0,
+                wall_clock_s=time.monotonic() - start,
+                heal_count=0,
+                halted=True,
+                terminal_outcome="error",
+                num_steps=0,
+                error=str(e),
+            )
+            out.append(metrics)
+            if on_task:
+                on_task(metrics)
+            continue
+
+        # WAA's own verifier is the source of truth for success.
+        if evaluator is not None:
+            try:
+                verified, reason = evaluator(task.task_id)
+                metrics.waa_verified_success = bool(verified)
+                if reason and not metrics.error:
+                    metrics.error = reason if not verified else None
+            except Exception as e:  # noqa: BLE001
+                logger.warning("WAA evaluator failed for %s: %s", task.task_id, e)
+                metrics.error = metrics.error or f"evaluator error: {e}"
+
+        out.append(metrics)
+        if on_task:
+            on_task(metrics)
+
+    return out
+
+
+def aggregate_replay_metrics(metrics: Sequence[PerTaskReplayMetrics]) -> dict:
+    """Aggregate per-task replay metrics into a summary dict."""
+    n = len(metrics)
+    if n == 0:
+        return {"num_tasks": 0}
+    verified = [m for m in metrics if m.waa_verified_success is not None]
+    verified_success = sum(1 for m in verified if m.waa_verified_success)
+    reported_success = sum(1 for m in metrics if m.replay_reported_success)
+    return {
+        "num_tasks": n,
+        "num_with_bundle": sum(1 for m in metrics if m.bundle_dir is not None),
+        "waa_verified_num_scored": len(verified),
+        "waa_verified_success": verified_success,
+        "waa_verified_success_rate": (
+            verified_success / len(verified) if verified else None
+        ),
+        "replay_reported_success": reported_success,
+        "replay_reported_success_rate": reported_success / n,
+        "total_model_calls": sum(m.model_calls for m in metrics),
+        "total_est_model_cost_usd": round(sum(m.est_model_cost_usd for m in metrics), 5),
+        "total_heal_events": sum(m.heal_count for m in metrics),
+        "num_halted": sum(1 for m in metrics if m.halted),
+        "total_wall_clock_s": round(sum(m.wall_clock_s for m in metrics), 3),
+        "num_missing_bundle": sum(
+            1 for m in metrics if m.error and "no compiled bundle" in (m.error or "")
+        ),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ waa = [
     # Windows Agent Arena dependencies
     "requests>=2.28.0",
 ]
+flow = [
+    # openadapt-flow: the demonstration compiler. Provides WindowsBackend
+    # (WAA /screenshot + /execute_windows contract), Replayer, Workflow, and
+    # run_bench. Only needed to actually replay/compile against a live WAA
+    # server -- the cost model + dry-run are stdlib-only and need no extra.
+    "openadapt-flow>=0.19.1",
+]
 azure = [
     # Azure ML dependencies for distributed WAA evaluation
     "azure-ai-ml>=1.12.0",
@@ -125,7 +132,7 @@ verl = [
     # on PyPI. Install from source: https://github.com/RAGEN-AI/VAGEN
 ]
 all = [
-    "openadapt-evals[dev,waa,azure,aws,retrieval,viewer,wandb]",
+    "openadapt-evals[dev,waa,flow,azure,aws,retrieval,viewer,wandb]",
 ]
 test = [
     "anthropic>=0.76.0",
@@ -142,6 +149,8 @@ oa-vm = "openadapt_evals.benchmarks.vm_cli:main"
 openadapt-train-grpo = "scripts.train_trl_grpo:main"
 openadapt-eval = "scripts.run_full_eval:main"
 openadapt-collect = "scripts.collect_distillation_data:main"
+# Evaluate openadapt-flow on WAA (demonstrate-then-replay + hybrid, dry-run)
+openadapt-eval-flow = "scripts.eval_flow_on_waa:main"
 openadapt-analyze = "openadapt_evals.analysis.cli:main"
 # GPU instance lifecycle (launch, serve, terminate)
 openadapt-gpu = "scripts.gpu_cli:main"

--- a/scripts/eval_flow_on_waa.py
+++ b/scripts/eval_flow_on_waa.py
@@ -99,7 +99,15 @@ def build_guard(args: argparse.Namespace) -> CostGuardConfig:
 
 
 def print_estimate(args: argparse.Namespace, guard: CostGuardConfig) -> dict:
-    """Print + return the cost estimate for the requested N and the full 154."""
+    """Print + return the cost estimate for the requested N and the full 154.
+
+    Parallels is a LOCAL environment: VM cost is $0 (native Apple-Silicon virt);
+    only the hybrid agent-fallback tokens (a cloud API) cost money. WAA is a
+    CLOUD environment: Azure VM-hours + agent tokens.
+    """
+    is_parallels = args.env == "parallels"
+    vm_hourly = 0.0 if is_parallels else args.vm_hourly
+    vm_label = "Local VM (Parallels):" if is_parallels else "Azure VM-hours:      "
     rows = []
     seen = []
     for n in [args.tasks if not args.task_ids else len(
@@ -113,17 +121,18 @@ def print_estimate(args: argparse.Namespace, guard: CostGuardConfig) -> dict:
             mode=args.mode,
             model_name=args.model,
             fallback_rate=args.fallback_rate,
-            vm_hourly=args.vm_hourly,
+            vm_hourly=vm_hourly,
         )
         rows.append(est.as_dict())
 
     print()
     print("=" * 78)
-    print(f"  COST ESTIMATE  (mode={args.mode}, model={MODELS[args.model].name})")
+    env_tag = "LOCAL $0 (Parallels)" if is_parallels else "CLOUD $ (WAA/Azure)"
+    print(f"  COST ESTIMATE  ({env_tag}, mode={args.mode}, model={MODELS[args.model].name})")
     print("=" * 78)
     for r in rows:
         print(f"\n  {r['num_tasks']} tasks:")
-        print(f"    Azure VM-hours:        {r['vm_hours']:.2f}  @ ${r['vm_hourly_usd']}/hr"
+        print(f"    {vm_label}  {r['vm_hours']:.2f} vm-hours @ ${r['vm_hourly_usd']}/hr"
               f"  = ${r['vm_cost_usd']:.2f}")
         print(f"    Agent token cost:      ${r['token_cost_usd']:.2f}"
               f"  (paid tasks={r['paid_tasks']}, {r['agent_steps_per_paid_task']} steps each)")
@@ -154,6 +163,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         description="Evaluate openadapt-flow on WAA (dry-run by default).",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    p.add_argument("--env", choices=["waa", "parallels"], default="waa",
+                   help="Environment: 'waa' = CLOUD Azure ($); 'parallels' = "
+                        "LOCAL Apple-Silicon VM ($0, opt-in OPENADAPT_PARALLELS=1).")
     p.add_argument("--mode", choices=["replay", "hybrid"], default="replay")
     p.add_argument("--tasks", type=int, default=10,
                    help="Number of tasks (used for the estimate when --task-ids is absent).")
@@ -185,16 +197,25 @@ def main(argv: Optional[list[str]] = None) -> int:
     guard = build_guard(args)
     plan = build_plan(args)
 
+    is_parallels = args.env == "parallels"
     print()
     print("=" * 78)
-    print(f"  openadapt-flow on WAA  --  mode={args.mode}")
+    env_label = "Parallels LOCAL VM ($0)" if is_parallels else "WAA / Azure CLOUD ($)"
+    print(f"  openadapt-flow on {env_label}  --  mode={args.mode}")
     print("=" * 78)
+    print(f"  environment:         {args.env}")
     print(f"  tasks:               {plan['num_tasks']}")
     print(f"  server-url:          {plan['server_url']}")
     print(f"  bundles-dir:         {plan['bundles_dir']}")
     print(f"  tasks with bundle:   {plan['tasks_with_bundle']}")
     print(f"  tasks MISSING bundle:{plan['tasks_missing_bundle']}"
           + ("  (record + compile first)" if plan["tasks_missing_bundle"] else ""))
+    if is_parallels:
+        from openadapt_evals.flow.parallels_env import PARALLELS_ENV_VAR, parallels_enabled
+
+        print(f"  opt-in gate:         {PARALLELS_ENV_VAR}="
+              f"{'set' if parallels_enabled() else 'UNSET (skipped)'}")
+        print("  snapshot-safe:       snapshot -> run -> revert (never deletes the VM)")
 
     estimate = print_estimate(args, guard)
 
@@ -204,10 +225,16 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if not args.live:
         print()
-        print("  DRY-RUN: no VM provisioned, no task run, no money spent.")
-        print("  A live run needs: Azure creds + a revived waa-pool VM"
-              " (oa-vm pool-create/pool-wait),")
-        print("  compiled bundles for each task, then re-run with --live.")
+        if is_parallels:
+            print("  DRY-RUN: no VM touched, no money spent.")
+            print("  A local run needs: Parallels + the Win11 VM + openadapt-flow"
+                  " (win_agent, PR #95),")
+            print("  compiled bundles per task, OPENADAPT_PARALLELS=1, then --live. $0.")
+        else:
+            print("  DRY-RUN: no VM provisioned, no task run, no money spent.")
+            print("  A live run needs: Azure creds + a revived waa-pool VM"
+                  " (oa-vm pool-create/pool-wait),")
+            print("  compiled bundles for each task, then re-run with --live.")
         return 0
 
     return _run_live(args, plan, guard)
@@ -226,6 +253,9 @@ def _run_live(args: argparse.Namespace, plan: dict, guard: CostGuardConfig) -> i
     if plan["tasks_missing_bundle"]:
         print("\n  REFUSING --live: some tasks have no compiled bundle.", file=sys.stderr)
         return 2
+
+    if args.env == "parallels":
+        return _run_live_parallels(args, plan, guard)
 
     print(f"\n  Probing WAA server at {args.server_url} ...")
     try:
@@ -264,6 +294,48 @@ def _run_live(args: argparse.Namespace, plan: dict, guard: CostGuardConfig) -> i
           "\n  with evaluate_agent_on_benchmark(agent, WAALiveAdapter(...)). Gated on go.",
           file=sys.stderr)
     return 3
+
+
+def _run_live_parallels(args: argparse.Namespace, plan: dict, guard: CostGuardConfig) -> int:
+    """Execute a LOCAL Parallels run ($0). GATED: opt-in + snapshot-safe.
+
+    Requires ``OPENADAPT_PARALLELS=1``. Snapshots the clean VM state, launches
+    the in-guest win_agent, replays each bundle via the SAME WindowsBackend path
+    as WAA, scores with OUR built-in verifiers, then reverts (never deletes the
+    VM). No cloud, no money. Only the (optional) hybrid agent-fallback tokens
+    cost anything, and those stay under the same guardrails.
+    """
+    from openadapt_evals.flow.parallels_env import (
+        ParallelsConfig,
+        ParallelsTask,
+        parallels_enabled,
+        run_parallels_replay,
+    )
+
+    if not parallels_enabled():
+        print("\n  REFUSING --live (parallels): opt-in gate is off. "
+              "Set OPENADAPT_PARALLELS=1.", file=sys.stderr)
+        return 2
+
+    if args.mode != "replay":
+        print("\n  Parallels --live currently supports the replay mode "
+              "(the compiled arm); hybrid fallback needs a per-step local adapter.",
+              file=sys.stderr)
+        return 3
+
+    config = ParallelsConfig(enabled=True)
+    tasks = [
+        ParallelsTask(
+            task_id=t["task_id"],
+            instruction=t["task_id"],
+            verify=lambda vm: (False, "supply a verifier for custom parallels tasks"),
+            bundle_dir=Path(t["bundle_dir"]),
+        )
+        for t in plan["tasks"]
+    ]
+    metrics, summary = run_parallels_replay(tasks, config, run_root=Path(args.run_root))
+    print(json.dumps({"env": "parallels", "summary": summary}, indent=2))
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/eval_flow_on_waa.py
+++ b/scripts/eval_flow_on_waa.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Evaluate openadapt-flow on WindowsAgentArena (WAA).
+
+Two eval modes, both scored by WAA's own task verifier:
+
+  replay  -- demonstrate-then-replay: compile ONE demo into a bundle and replay
+             it via WindowsBackend against the WAA in-guest server (~0 model
+             calls). Paradigm-correct eval for a demonstration compiler.
+  hybrid  -- compiled replay first, computer-use agent fallback ONLY on a
+             detected halt. Drive-able by the WAA runner; directly comparable
+             to a pure agent baseline on the same tasks.
+
+Safety: this command is **dry-run by default**. It never provisions Azure,
+never starts a VM, never spends money, and makes no network calls unless you
+pass ``--live`` (which additionally requires a reachable WAA server and stays
+under the hard cost caps). The prior $40-70 uncapped-run incident is why the
+caps below are mandatory.
+
+Examples:
+    # Cost estimate + plan for a 10-task and full (154) replay run (no network):
+    python scripts/eval_flow_on_waa.py --mode replay --tasks 10 --dry-run
+    python scripts/eval_flow_on_waa.py --mode replay --tasks 154 --dry-run
+
+    # Hybrid dry-run with an assumed 30% halt/fallback rate:
+    python scripts/eval_flow_on_waa.py --mode hybrid --tasks 154 --fallback-rate 0.3 --dry-run
+
+    # Live run (GATED: needs Azure + a revived waa-pool + maintainer go):
+    python scripts/eval_flow_on_waa.py --mode replay --task-ids <id1>,<id2> \
+        --bundles ./flow_bundles --server-url http://localhost:5001 --live
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Ensure repo root on path when run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from openadapt_evals.flow.cost import (  # noqa: E402
+    DEFAULT_MODEL,
+    MODELS,
+    CostGuardConfig,
+    SpendLedger,
+    estimate_flow_waa_cost,
+)
+
+FULL_BENCHMARK_TASKS = 154
+
+
+def _discover_bundle(bundles_dir: Optional[Path], task_id: str) -> Optional[Path]:
+    """Return ``<bundles_dir>/<task_id>`` if it is a compiled bundle, else None."""
+    if bundles_dir is None:
+        return None
+    candidate = bundles_dir / task_id
+    if (candidate / "workflow.json").exists():
+        return candidate
+    return None
+
+
+def build_plan(args: argparse.Namespace) -> dict:
+    """Build the run plan (task list + bundle discovery). No network."""
+    bundles_dir = Path(args.bundles) if args.bundles else None
+    task_ids: list[str]
+    if args.task_ids:
+        task_ids = [t.strip() for t in args.task_ids.split(",") if t.strip()]
+    else:
+        task_ids = [f"task_{i:03d}" for i in range(args.tasks)]
+
+    tasks = []
+    missing = 0
+    for tid in task_ids:
+        bundle = _discover_bundle(bundles_dir, tid)
+        if bundle is None:
+            missing += 1
+        tasks.append({"task_id": tid, "bundle_dir": str(bundle) if bundle else None})
+
+    return {
+        "mode": args.mode,
+        "num_tasks": len(task_ids),
+        "server_url": args.server_url,
+        "bundles_dir": str(bundles_dir) if bundles_dir else None,
+        "tasks_with_bundle": len(task_ids) - missing,
+        "tasks_missing_bundle": missing,
+        "tasks": tasks,
+    }
+
+
+def build_guard(args: argparse.Namespace) -> CostGuardConfig:
+    return CostGuardConfig(
+        per_run_usd=args.max_run_usd,
+        total_usd=args.max_total_usd,
+        per_task_tokens=args.max_task_tokens,
+        billing_abort_after=args.billing_abort_after,
+    )
+
+
+def print_estimate(args: argparse.Namespace, guard: CostGuardConfig) -> dict:
+    """Print + return the cost estimate for the requested N and the full 154."""
+    rows = []
+    seen = []
+    for n in [args.tasks if not args.task_ids else len(
+        [t for t in args.task_ids.split(",") if t.strip()]
+    ), FULL_BENCHMARK_TASKS]:
+        if n in seen:
+            continue
+        seen.append(n)
+        est = estimate_flow_waa_cost(
+            n,
+            mode=args.mode,
+            model_name=args.model,
+            fallback_rate=args.fallback_rate,
+            vm_hourly=args.vm_hourly,
+        )
+        rows.append(est.as_dict())
+
+    print()
+    print("=" * 78)
+    print(f"  COST ESTIMATE  (mode={args.mode}, model={MODELS[args.model].name})")
+    print("=" * 78)
+    for r in rows:
+        print(f"\n  {r['num_tasks']} tasks:")
+        print(f"    Azure VM-hours:        {r['vm_hours']:.2f}  @ ${r['vm_hourly_usd']}/hr"
+              f"  = ${r['vm_cost_usd']:.2f}")
+        print(f"    Agent token cost:      ${r['token_cost_usd']:.2f}"
+              f"  (paid tasks={r['paid_tasks']}, {r['agent_steps_per_paid_task']} steps each)")
+        print(f"    -> TOTAL:              ${r['total_cost_usd']:.2f}"
+              f"   (${r['cost_per_task_usd']:.4f}/task)")
+        print(f"    Pure-agent baseline:   ${r['baseline_pure_agent_cost_usd']:.2f}"
+              f"   ({r['baseline_agent_steps_per_task']} steps/task, all paid)")
+        print(f"    Savings vs baseline:   ${r['savings_vs_baseline_usd']:.2f}")
+
+    print()
+    print("  HARD GUARDRAILS (enforced on any --live paid run):")
+    print(f"    per-run cap:      ${guard.per_run_usd:.2f}")
+    print(f"    total cap:        ${guard.total_usd:.2f}")
+    print(f"    per-task tokens:  {guard.per_task_tokens:,}")
+    print(f"    billing-abort:    after {guard.billing_abort_after} consecutive errors")
+
+    requested = rows[0]
+    if requested["total_cost_usd"] > guard.total_usd:
+        print()
+        print(f"  WARNING: estimated total ${requested['total_cost_usd']:.2f} exceeds the "
+              f"total cap ${guard.total_usd:.2f}. Raise --max-total-usd or reduce --tasks "
+              f"before a --live run.")
+    return {"estimates": rows, "guardrails": guard.__dict__}
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Evaluate openadapt-flow on WAA (dry-run by default).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--mode", choices=["replay", "hybrid"], default="replay")
+    p.add_argument("--tasks", type=int, default=10,
+                   help="Number of tasks (used for the estimate when --task-ids is absent).")
+    p.add_argument("--task-ids", type=str, default=None,
+                   help="Comma-separated WAA task IDs to run.")
+    p.add_argument("--bundles", type=str, default=None,
+                   help="Directory of compiled bundles, one per task_id subdir.")
+    p.add_argument("--server-url", type=str, default="http://localhost:5001")
+    p.add_argument("--model", choices=sorted(MODELS), default=DEFAULT_MODEL,
+                   help="Fallback / baseline computer-use model for cost.")
+    p.add_argument("--fallback-rate", type=float, default=0.30,
+                   help="Assumed fraction of tasks that halt -> paid fallback (hybrid).")
+    p.add_argument("--vm-hourly", type=float, default=0.19,
+                   help="VM $/hour (Azure D4_v3=0.19, AWS m8i.2xlarge=0.46).")
+    # Guardrails (mandatory for any paid run).
+    p.add_argument("--max-run-usd", type=float, default=0.50)
+    p.add_argument("--max-total-usd", type=float, default=5.00)
+    p.add_argument("--max-task-tokens", type=int, default=60_000)
+    p.add_argument("--billing-abort-after", type=int, default=2)
+    # Execution.
+    p.add_argument("--dry-run", action="store_true",
+                   help="Print the plan + cost estimate and exit (default when --live absent).")
+    p.add_argument("--live", action="store_true",
+                   help="Actually run against a reachable WAA server (GATED; needs Azure + $).")
+    p.add_argument("--run-root", type=str, default="flow_waa_results")
+    p.add_argument("--json", action="store_true", help="Also emit the plan+estimate as JSON.")
+    args = p.parse_args(argv)
+
+    guard = build_guard(args)
+    plan = build_plan(args)
+
+    print()
+    print("=" * 78)
+    print(f"  openadapt-flow on WAA  --  mode={args.mode}")
+    print("=" * 78)
+    print(f"  tasks:               {plan['num_tasks']}")
+    print(f"  server-url:          {plan['server_url']}")
+    print(f"  bundles-dir:         {plan['bundles_dir']}")
+    print(f"  tasks with bundle:   {plan['tasks_with_bundle']}")
+    print(f"  tasks MISSING bundle:{plan['tasks_missing_bundle']}"
+          + ("  (record + compile first)" if plan["tasks_missing_bundle"] else ""))
+
+    estimate = print_estimate(args, guard)
+
+    if args.json:
+        print()
+        print(json.dumps({"plan": plan, **estimate}, indent=2, default=str))
+
+    if not args.live:
+        print()
+        print("  DRY-RUN: no VM provisioned, no task run, no money spent.")
+        print("  A live run needs: Azure creds + a revived waa-pool VM"
+              " (oa-vm pool-create/pool-wait),")
+        print("  compiled bundles for each task, then re-run with --live.")
+        return 0
+
+    return _run_live(args, plan, guard)
+
+
+def _run_live(args: argparse.Namespace, plan: dict, guard: CostGuardConfig) -> int:
+    """Execute a real run. GATED: requires a reachable WAA server + bundles.
+
+    This path does NOT create or start any Azure/AWS resource -- it assumes a
+    WAA server is already reachable at ``--server-url`` (revive the pool with
+    ``oa-vm pool-create`` / ``oa-vm pool-wait`` first). Kept minimal on purpose;
+    the maintainer's explicit go is required before running it.
+    """
+    import requests  # local import: not needed for dry-run
+
+    if plan["tasks_missing_bundle"]:
+        print("\n  REFUSING --live: some tasks have no compiled bundle.", file=sys.stderr)
+        return 2
+
+    print(f"\n  Probing WAA server at {args.server_url} ...")
+    try:
+        resp = requests.get(f"{args.server_url}/probe", timeout=5)
+        resp.raise_for_status()
+    except Exception as e:  # noqa: BLE001
+        print(f"  REFUSING --live: WAA server not reachable: {e}", file=sys.stderr)
+        return 2
+
+    ledger = SpendLedger(guard)
+    run_root = Path(args.run_root)
+
+    if args.mode == "replay":
+        from openadapt_evals.flow.replay_runner import (
+            FlowTask,
+            aggregate_replay_metrics,
+            run_demonstrate_then_replay,
+        )
+
+        tasks = [
+            FlowTask(task_id=t["task_id"], bundle_dir=Path(t["bundle_dir"]))
+            for t in plan["tasks"]
+        ]
+        # NOTE: wire a real WAA evaluator here (WAALiveAdapter.evaluate) once the
+        # maintainer approves a live run; left None so replay is not falsely
+        # self-scored.
+        metrics = run_demonstrate_then_replay(tasks, args.server_url, run_root)
+        summary = aggregate_replay_metrics(metrics)
+        # Replay makes ~0 model calls, so the paid ledger should stay at $0;
+        # report it for transparency (and to prove no silent spend).
+        print(json.dumps({"summary": summary, "ledger": ledger.summary()}, indent=2))
+        return 0
+
+    print("\n  hybrid --live requires a base computer-use agent + WAALiveAdapter wiring;"
+          "\n  construct HybridFlowAgent(base_agent, bundle, server_url, ledger) and drive it"
+          "\n  with evaluate_agent_on_benchmark(agent, WAALiveAdapter(...)). Gated on go.",
+          file=sys.stderr)
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/waa_cost_estimate.py
+++ b/scripts/waa_cost_estimate.py
@@ -212,12 +212,12 @@ def print_results():
     print("## Image Token Calculation")
     w, h = WAA_PARAMS['screenshot_width'], WAA_PARAMS['screenshot_height']
     print(f"   OpenAI (GPT-4o): {openai_image_tokens(w, h)} tokens")
-    print(f"     - Formula: 85 + (170 × tiles), where tiles = ceil(W/512) × ceil(H/512)")
-    print(f"     - 1920x1080 → scaled to 1365x768 → 3×2=6 tiles → 85 + 170×6 = 1,105 tokens")
+    print("     - Formula: 85 + (170 × tiles), where tiles = ceil(W/512) × ceil(H/512)")
+    print("     - 1920x1080 → scaled to 1365x768 → 3×2=6 tiles → 85 + 170×6 = 1,105 tokens")
     print()
     print(f"   Anthropic (Claude): {claude_image_tokens(w, h)} tokens")
-    print(f"     - Formula: (W × H) / 750")
-    print(f"     - 1920x1080 → scaled to 1568×882 → 1,568×882/750 = 1,844 tokens")
+    print("     - Formula: (W × H) / 750")
+    print("     - 1920x1080 → scaled to 1568×882 → 1,568×882/750 = 1,844 tokens")
     print()
 
     # Cost summary table
@@ -276,5 +276,56 @@ def print_results():
         print(f"   {result['model']:<16} ${result['total_cost']:>7.2f} {bar}")
 
 
+def _flow_estimate_main(argv=None) -> int:
+    """Flow-aware estimate: extends the legacy table with the demonstrate-then-
+    replay / hybrid modes and a cost-guarded --dry-run.
+
+    Delegates to :mod:`openadapt_evals.flow.cost` (the canonical cost model) so
+    the numbers match ``scripts/eval_flow_on_waa.py``.
+    """
+    import argparse
+    from pathlib import Path
+    import sys as _sys
+
+    _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from openadapt_evals.flow.cost import MODELS as FLOW_MODELS
+    from openadapt_evals.flow.cost import estimate_flow_waa_cost
+
+    ap = argparse.ArgumentParser(
+        description="WAA cost estimate (legacy vision table, or flow-aware modes)."
+    )
+    ap.add_argument("--tasks", type=int, default=154)
+    ap.add_argument("--mode", choices=["legacy", "replay", "hybrid"], default="legacy")
+    ap.add_argument("--model", choices=sorted(FLOW_MODELS), default="claude-sonnet-4")
+    ap.add_argument("--fallback-rate", type=float, default=0.30)
+    ap.add_argument("--vm-hourly", type=float, default=0.19)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print the estimate and exit (never provisions anything).")
+    args = ap.parse_args(argv)
+
+    if args.mode == "legacy":
+        print_results()
+        return 0
+
+    est = estimate_flow_waa_cost(
+        args.tasks, mode=args.mode, model_name=args.model,
+        fallback_rate=args.fallback_rate, vm_hourly=args.vm_hourly,
+    )
+    d = est.as_dict()
+    print(f"mode={d['mode']} tasks={d['num_tasks']} model={d['model']}")
+    print(f"  Azure VM cost:        ${d['vm_cost_usd']:.2f}  ({d['vm_hours']:.2f} vm-hours)")
+    print(f"  Agent token cost:     ${d['token_cost_usd']:.2f}")
+    print(f"  TOTAL:                ${d['total_cost_usd']:.2f}  (${d['cost_per_task_usd']:.4f}/task)")
+    print(f"  Pure-agent baseline:  ${d['baseline_pure_agent_cost_usd']:.2f}")
+    print(f"  Savings vs baseline:  ${d['savings_vs_baseline_usd']:.2f}")
+    if args.dry_run:
+        print("  (dry-run: no VM provisioned, no money spent)")
+    return 0
+
+
 if __name__ == "__main__":
+    import sys as _sys
+    # Backward compatible: no args -> the legacy table. Any flag -> flow-aware.
+    if len(_sys.argv) > 1:
+        raise SystemExit(_flow_estimate_main())
     print_results()

--- a/tests/test_eval_flow_on_waa_dryrun.py
+++ b/tests/test_eval_flow_on_waa_dryrun.py
@@ -63,3 +63,29 @@ def test_live_refuses_when_bundle_missing_without_network(capsys):
     err = capsys.readouterr().err
     assert rc == 2
     assert "no compiled bundle" in err.lower()
+
+
+def test_parallels_dry_run_is_zero_dollars(capsys):
+    rc = efw.main(["--env", "parallels", "--mode", "replay", "--tasks", "2"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Parallels LOCAL VM ($0)" in out
+    assert "LOCAL $0 (Parallels)" in out
+    assert "= $0.00" in out
+    assert "OPENADAPT_PARALLELS" in out
+    assert "snapshot -> run -> revert" in out
+
+
+def test_parallels_live_refused_without_optin(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv("OPENADAPT_PARALLELS", raising=False)
+    # A present bundle so we pass the missing-bundle gate and reach the opt-in check.
+    bundle = tmp_path / "notepad_write"
+    bundle.mkdir()
+    (bundle / "workflow.json").write_text("{}")
+    rc = efw.main([
+        "--env", "parallels", "--mode", "replay",
+        "--task-ids", "notepad_write", "--bundles", str(tmp_path), "--live",
+    ])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "opt-in" in err.lower()

--- a/tests/test_eval_flow_on_waa_dryrun.py
+++ b/tests/test_eval_flow_on_waa_dryrun.py
@@ -1,0 +1,65 @@
+"""Tests for the eval_flow_on_waa CLI (dry-run: no network, no Azure, no $)."""
+
+import importlib.util
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "eval_flow_on_waa.py"
+_spec = importlib.util.spec_from_file_location("eval_flow_on_waa", _SCRIPT)
+efw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(efw)
+
+
+def test_dry_run_default_returns_zero_replay_10(capsys):
+    rc = efw.main(["--mode", "replay", "--tasks", "10"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "DRY-RUN" in out
+    assert "COST ESTIMATE" in out
+    assert "10 tasks" in out
+    assert "154 tasks" in out            # full-benchmark reference always shown
+
+
+def test_dry_run_full_benchmark_154(capsys):
+    rc = efw.main(["--mode", "replay", "--tasks", "154", "--dry-run"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "154 tasks" in out
+    assert "Pure-agent baseline" in out
+
+
+def test_hybrid_dry_run_shows_fallback_cost(capsys):
+    rc = efw.main(["--mode", "hybrid", "--tasks", "154", "--fallback-rate", "0.3", "--dry-run"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Agent token cost" in out
+    # Hybrid pays something for fallbacks; replay would not.
+    est = efw.estimate_flow_waa_cost(154, mode="hybrid", fallback_rate=0.3)
+    assert est.token_cost_usd > 0
+
+
+def test_guardrails_are_printed(capsys):
+    efw.main(["--tasks", "10"])
+    out = capsys.readouterr().out
+    assert "HARD GUARDRAILS" in out
+    assert "per-run cap" in out
+    assert "total cap" in out
+
+
+def test_json_output(capsys):
+    rc = efw.main(["--tasks", "5", "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"plan"' in out and '"estimates"' in out
+
+
+def test_live_refuses_when_bundle_missing_without_network(capsys):
+    # --live with task-ids that have no bundles must refuse BEFORE any probe,
+    # so this makes no network call.
+    rc = efw.main([
+        "--mode", "replay", "--task-ids", "id_a,id_b",
+        "--bundles", "/tmp/nonexistent_bundles_dir", "--live",
+    ])
+    err = capsys.readouterr().err
+    assert rc == 2
+    assert "no compiled bundle" in err.lower()

--- a/tests/test_flow_hybrid_agent.py
+++ b/tests/test_flow_hybrid_agent.py
@@ -1,0 +1,137 @@
+"""Tests for the hybrid-as-agent adapter (fully mocked; no flow, no VM)."""
+
+import sys
+from types import SimpleNamespace
+
+from openadapt_evals.adapters.base import (
+    BenchmarkAction,
+    BenchmarkObservation,
+    BenchmarkTask,
+)
+from openadapt_evals.agents.base import BenchmarkAgent
+from openadapt_evals.flow.cost import CostGuardConfig, SpendLedger
+from openadapt_evals.flow.hybrid_agent import HybridFlowAgent
+
+
+class ScriptedAgent(BenchmarkAgent):
+    """A base computer-use agent that emits a fixed action sequence."""
+
+    def __init__(self, actions, step_cost=0.05, step_tokens=1000):
+        self._actions = list(actions)
+        self._i = 0
+        self._step_cost = step_cost
+        self._step_tokens = step_tokens
+        self._last_step_logs = None
+        self.reset_called = 0
+
+    def act(self, observation, task, history=None):
+        self._last_step_logs = {"cost_usd": self._step_cost, "total_tokens": self._step_tokens}
+        if self._i < len(self._actions):
+            a = self._actions[self._i]
+            self._i += 1
+            return a
+        return BenchmarkAction(type="done")
+
+    def reset(self):
+        self.reset_called += 1
+        self._i = 0
+
+
+def _obs():
+    return BenchmarkObservation(viewport=(1920, 1080))
+
+
+def _task():
+    return BenchmarkTask(task_id="waa_t", instruction="do it", domain="notepad")
+
+
+def _report(success, terminal, model_calls=0):
+    return SimpleNamespace(
+        success=success, terminal_outcome=terminal, model_calls=model_calls,
+        heal_count=0, rung_counts={"primary": 3}, est_model_cost_usd=0.0,
+        results=[object()] * 3,
+    )
+
+
+def test_healthy_replay_returns_done_without_paying(tmp_path):
+    base = ScriptedAgent([])
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x",
+        replay_fn=lambda *a: _report(True, "success"),
+    )
+    action = agent.act(_obs(), _task())
+    assert action.type == "done"
+    assert agent.metrics["fallback_used"] is False
+    assert agent.ledger.spent == 0.0        # compiled arm is free
+
+
+def test_halt_triggers_agent_fallback(tmp_path):
+    click = BenchmarkAction(type="click", x=10, y=10)
+    base = ScriptedAgent([click])
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x",
+        replay_fn=lambda *a: _report(False, "halt"),
+    )
+    # First act: replay halts -> falls back and returns the base agent's action.
+    a1 = agent.act(_obs(), _task())
+    assert a1 is click
+    assert agent.metrics["fallback_used"] is True
+    assert agent._last_step_logs["cost_usd"] == 0.05     # cost surfaced to the runner
+
+    # Ledger records the episode's fallback spend on reset/finalize.
+    agent.finalize_episode()
+    assert agent.ledger.spent > 0
+    assert agent.ledger.tokens_used == 1000
+
+
+def test_fallback_blocked_when_ledger_cannot_start(tmp_path):
+    ledger = SpendLedger(CostGuardConfig(per_run_usd=0.5, total_usd=0.4))  # cap < per-run
+    base = ScriptedAgent([BenchmarkAction(type="click", x=1, y=1)])
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x", ledger=ledger,
+        replay_fn=lambda *a: _report(False, "halt"),
+    )
+    action = agent.act(_obs(), _task())
+    assert action.type == "error"
+    assert "blocked" in action.raw_action["reason"]
+    assert agent.metrics["fallback_used"] is False
+
+
+def test_per_task_token_cap_stops_fallback(tmp_path):
+    ledger = SpendLedger(CostGuardConfig(per_task_tokens=1500, total_usd=100))
+    base = ScriptedAgent(
+        [BenchmarkAction(type="click", x=1, y=1) for _ in range(5)],
+        step_tokens=2000,
+    )
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x", ledger=ledger,
+        replay_fn=lambda *a: _report(False, "halt"),
+    )
+    a1 = agent.act(_obs(), _task())       # 2000 tokens used
+    assert a1.type == "click"
+    a2 = agent.act(_obs(), _task())       # 2000 > 1500 cap -> error
+    assert a2.type == "error"
+    assert "token cap" in a2.raw_action["reason"]
+
+
+def test_reset_finalizes_previous_episode_and_resets_base(tmp_path):
+    base = ScriptedAgent([BenchmarkAction(type="click", x=1, y=1)])
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x",
+        replay_fn=lambda *a: _report(False, "halt"),
+    )
+    agent.act(_obs(), _task())
+    agent.reset()
+    assert base.reset_called == 1
+    assert agent.ledger.spent > 0         # previous episode recorded exactly once
+    assert agent._fallback_mode is False
+
+
+def test_no_openadapt_flow_import(tmp_path):
+    base = ScriptedAgent([])
+    agent = HybridFlowAgent(
+        base, bundle_dir=tmp_path, server_url="http://x",
+        replay_fn=lambda *a: _report(True, "success"),
+    )
+    agent.act(_obs(), _task())
+    assert "openadapt_flow" not in sys.modules

--- a/tests/test_flow_hybrid_agent.py
+++ b/tests/test_flow_hybrid_agent.py
@@ -72,10 +72,13 @@ def test_halt_triggers_agent_fallback(tmp_path):
         base, bundle_dir=tmp_path, server_url="http://x",
         replay_fn=lambda *a: _report(False, "halt"),
     )
-    # First act: replay halts -> falls back and returns the base agent's action.
+    # First act: replay halts -> a no-op WAIT primes a fresh post-replay obs.
     a1 = agent.act(_obs(), _task())
-    assert a1 is click
+    assert a1.type == "wait"
     assert agent.metrics["fallback_used"] is True
+    # Second act: the base computer-use agent acts on the fresh observation.
+    a2 = agent.act(_obs(), _task())
+    assert a2 is click
     assert agent._last_step_logs["cost_usd"] == 0.05     # cost surfaced to the runner
 
     # Ledger records the episode's fallback spend on reset/finalize.
@@ -107,6 +110,8 @@ def test_per_task_token_cap_stops_fallback(tmp_path):
         base, bundle_dir=tmp_path, server_url="http://x", ledger=ledger,
         replay_fn=lambda *a: _report(False, "halt"),
     )
+    prime = agent.act(_obs(), _task())    # WAIT primer (no base step yet)
+    assert prime.type == "wait"
     a1 = agent.act(_obs(), _task())       # 2000 tokens used
     assert a1.type == "click"
     a2 = agent.act(_obs(), _task())       # 2000 > 1500 cap -> error
@@ -120,7 +125,8 @@ def test_reset_finalizes_previous_episode_and_resets_base(tmp_path):
         base, bundle_dir=tmp_path, server_url="http://x",
         replay_fn=lambda *a: _report(False, "halt"),
     )
-    agent.act(_obs(), _task())
+    agent.act(_obs(), _task())            # WAIT primer
+    agent.act(_obs(), _task())            # real fallback step (spends)
     agent.reset()
     assert base.reset_called == 1
     assert agent.ledger.spent > 0         # previous episode recorded exactly once

--- a/tests/test_flow_parallels_env.py
+++ b/tests/test_flow_parallels_env.py
@@ -1,0 +1,167 @@
+"""Tests for the Parallels local-VM environment (fully mocked; no prlctl, no VM).
+
+Snapshot-safety is asserted structurally: the fake VM raises if anything ever
+tries to stop or delete it, and the session must snapshot before running and
+revert after.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from openadapt_evals.flow.parallels_env import (
+    PARALLELS_ENV_VAR,
+    ParallelsConfig,
+    ParallelsSession,
+    ParallelsTask,
+    builtin_tasks,
+    parallels_enabled,
+    run_parallels_replay,
+    verify_calculator_open,
+    verify_notepad_file,
+)
+
+
+class FakeParallelsVM:
+    """Records lifecycle calls; explodes if anyone stops or deletes the VM."""
+
+    def __init__(self, exec_stdout=""):
+        self.calls = []
+        self._exec_stdout = exec_stdout
+        self.reverted_to = None
+
+    def ensure_running(self, *, settle_s=6.0):
+        self.calls.append("ensure_running")
+
+    def snapshot(self, name, description=""):
+        self.calls.append(f"snapshot:{name}")
+        return "snap-123"
+
+    def launch_agent(self, *, port, host, token, wait_s=25.0, host_ip=None):
+        self.calls.append(f"launch_agent:{host}:{port}")
+        self.token = token
+        return f"http://guest:{port}"
+
+    def revert(self, snapshot_id):
+        self.calls.append(f"revert:{snapshot_id}")
+        self.reverted_to = snapshot_id
+
+    def exec_ps(self, cmd):
+        return SimpleNamespace(stdout=self._exec_stdout, returncode=0, stderr="")
+
+    def exec_cmd(self, cmd):
+        return SimpleNamespace(stdout=self._exec_stdout, returncode=0, stderr="")
+
+    # Snapshot-safety: these must NEVER be called by the harness.
+    def stop(self, *a, **k):
+        raise AssertionError("harness must never stop the user's VM")
+
+    def delete(self, *a, **k):
+        raise AssertionError("harness must never delete the user's VM")
+
+
+def _report(success=True, terminal="success"):
+    return SimpleNamespace(
+        success=success, terminal_outcome=terminal, rung_counts={"primary": 3},
+        heal_count=0, model_calls=0, est_model_cost_usd=0.0, total_ms=10.0,
+        results=[object()] * 3,
+    )
+
+
+def test_opt_in_gate_default_off(monkeypatch):
+    monkeypatch.delenv(PARALLELS_ENV_VAR, raising=False)
+    assert parallels_enabled() is False
+    # Session refuses to enter when not opted in.
+    with pytest.raises(RuntimeError, match="opt-in"):
+        with ParallelsSession(ParallelsConfig(), vm=FakeParallelsVM()):
+            pass
+
+
+def test_opt_in_via_env(monkeypatch):
+    monkeypatch.setenv(PARALLELS_ENV_VAR, "1")
+    assert parallels_enabled() is True
+
+
+def test_opt_in_via_config():
+    assert parallels_enabled(ParallelsConfig(enabled=True)) is True
+
+
+def test_session_is_snapshot_safe():
+    vm = FakeParallelsVM()
+    cfg = ParallelsConfig(enabled=True, snapshot_name="clean")
+    with ParallelsSession(cfg, vm=vm) as sess:
+        assert sess.server_url == "http://guest:5000"
+    # snapshot BEFORE launch, revert on exit, never stop/delete.
+    assert vm.calls == [
+        "ensure_running",
+        "snapshot:clean",
+        "launch_agent:0.0.0.0:5000",
+        "revert:snap-123",
+    ]
+    assert vm.reverted_to == "snap-123"
+
+
+def test_session_reverts_even_on_error():
+    vm = FakeParallelsVM()
+    cfg = ParallelsConfig(enabled=True)
+    with pytest.raises(ValueError):
+        with ParallelsSession(cfg, vm=vm):
+            raise ValueError("boom during run")
+    assert any(c.startswith("revert:") for c in vm.calls)  # clean reset still happened
+
+
+def test_run_parallels_replay_scores_with_our_verifier(tmp_path):
+    vm = FakeParallelsVM(exec_stdout="openadapt-flow replay ok")
+    bundle = tmp_path / "notepad_write"
+    bundle.mkdir()
+    task = ParallelsTask(
+        task_id="notepad_write",
+        instruction="write a file",
+        verify=verify_notepad_file,
+        bundle_dir=bundle,
+    )
+    metrics, summary = run_parallels_replay(
+        [task], ParallelsConfig(enabled=True), vm=vm,
+        replay_fn=lambda *a: _report(success=True),
+        run_root=tmp_path / "runs",
+    )
+    m = metrics[0]
+    assert m.replay_reported_success is True
+    assert m.waa_verified_success is True       # OUR ground-truth verifier passed
+    assert m.model_calls == 0                   # replay is model-free / $0
+    assert summary["waa_verified_success"] == 1
+    assert vm.reverted_to == "snap-123"         # snapshot-safe reset happened
+
+
+def test_notepad_verifier_reads_in_guest_state():
+    ok, reason = verify_notepad_file(FakeParallelsVM(exec_stdout="openadapt-flow replay ok"))
+    assert ok is True
+    bad, _ = verify_notepad_file(FakeParallelsVM(exec_stdout="MISSING"))
+    assert bad is False
+
+
+def test_calculator_verifier():
+    ok, _ = verify_calculator_open(FakeParallelsVM(exec_stdout="CalculatorApp.exe  1234 Console"))
+    assert ok is True
+    bad, _ = verify_calculator_open(FakeParallelsVM(exec_stdout="INFO: No tasks."))
+    assert bad is False
+
+
+def test_builtin_tasks_flag_missing_bundles(tmp_path):
+    tasks = builtin_tasks(bundles_dir=tmp_path)  # empty dir -> no bundles
+    assert {t.task_id for t in tasks} == {"notepad_write", "calculator_open"}
+    assert all(t.bundle_dir is None for t in tasks)
+
+
+def test_no_openadapt_flow_import(tmp_path):
+    vm = FakeParallelsVM(exec_stdout="openadapt-flow replay ok")
+    b = tmp_path / "notepad_write"
+    b.mkdir()
+    run_parallels_replay(
+        [ParallelsTask("notepad_write", "x", verify_notepad_file, bundle_dir=b)],
+        ParallelsConfig(enabled=True), vm=vm,
+        replay_fn=lambda *a: _report(),
+        run_root=tmp_path / "r",
+    )
+    assert "openadapt_flow" not in sys.modules

--- a/tests/test_flow_replay_runner.py
+++ b/tests/test_flow_replay_runner.py
@@ -1,0 +1,136 @@
+"""Tests for the demonstrate-then-replay runner (fully mocked; no flow, no VM)."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from openadapt_evals.flow.replay_runner import (
+    FlowTask,
+    aggregate_replay_metrics,
+    run_demonstrate_then_replay,
+)
+
+
+def _fake_report(success=True, terminal="success", rungs=None, model_calls=0,
+                 heal=0, n_steps=5):
+    return SimpleNamespace(
+        success=success,
+        terminal_outcome=terminal,
+        rung_counts=rungs or {"primary": n_steps},
+        heal_count=heal,
+        model_calls=model_calls,
+        est_model_cost_usd=0.0,
+        total_ms=1234.0,
+        results=[object()] * n_steps,
+    )
+
+
+def test_healthy_replay_scored_by_waa_verifier(tmp_path):
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    tasks = [FlowTask("waa_task_1", bundle_dir=bundle)]
+
+    def replay_fn(bundle_dir, server_url, run_dir, params):
+        assert Path(bundle_dir) == bundle
+        assert server_url == "http://localhost:5001"
+        return _fake_report(success=True, terminal="success", model_calls=0)
+
+    def evaluator(task_id):
+        assert task_id == "waa_task_1"
+        return True, None
+
+    metrics = run_demonstrate_then_replay(
+        tasks, "http://localhost:5001", tmp_path / "runs",
+        replay_fn=replay_fn, evaluator=evaluator,
+    )
+    m = metrics[0]
+    assert m.waa_verified_success is True      # ground truth, not self-report
+    assert m.replay_reported_success is True
+    assert m.model_calls == 0                  # ~0 model calls on healthy replay
+    assert m.halted is False
+    assert m.rung_fire_rate > 0
+
+
+def test_halted_replay_marked_and_verifier_can_disagree(tmp_path):
+    bundle = tmp_path / "b"
+    bundle.mkdir()
+    tasks = [FlowTask("t", bundle_dir=bundle)]
+
+    def replay_fn(*a):
+        return _fake_report(success=False, terminal="halt")
+
+    def evaluator(task_id):
+        return False, "state check failed"
+
+    m = run_demonstrate_then_replay(
+        tasks, "http://x", tmp_path / "r", replay_fn=replay_fn, evaluator=evaluator
+    )[0]
+    assert m.halted is True
+    assert m.waa_verified_success is False
+    assert m.error == "state check failed"
+
+
+def test_missing_bundle_is_flagged_not_faked(tmp_path):
+    tasks = [FlowTask("no_bundle", bundle_dir=tmp_path / "does_not_exist")]
+    calls = []
+
+    def replay_fn(*a):
+        calls.append(a)
+        return _fake_report()
+
+    m = run_demonstrate_then_replay(
+        tasks, "http://x", tmp_path / "r", replay_fn=replay_fn
+    )[0]
+    assert not calls                      # replay never invoked for a missing bundle
+    assert "no compiled bundle" in m.error
+    assert m.waa_verified_success is None
+
+
+def test_replay_exception_is_isolated(tmp_path):
+    b1 = tmp_path / "b1"
+    b1.mkdir()
+    b2 = tmp_path / "b2"
+    b2.mkdir()
+
+    def replay_fn(bundle_dir, *a):
+        if Path(bundle_dir) == b1:
+            raise RuntimeError("backend blew up")
+        return _fake_report()
+
+    metrics = run_demonstrate_then_replay(
+        [FlowTask("bad", bundle_dir=b1), FlowTask("good", bundle_dir=b2)],
+        "http://x", tmp_path / "r", replay_fn=replay_fn,
+    )
+    assert metrics[0].error and "backend blew up" in metrics[0].error
+    assert metrics[0].halted is True
+    assert metrics[1].replay_reported_success is True   # second task still ran
+
+
+def test_aggregate(tmp_path):
+    b = tmp_path / "b"
+    b.mkdir()
+
+    def replay_fn(*a):
+        return _fake_report(success=True, model_calls=0)
+
+    metrics = run_demonstrate_then_replay(
+        [FlowTask(f"t{i}", bundle_dir=b) for i in range(3)],
+        "http://x", tmp_path / "r", replay_fn=replay_fn,
+        evaluator=lambda tid: (True, None),
+    )
+    agg = aggregate_replay_metrics(metrics)
+    assert agg["num_tasks"] == 3
+    assert agg["waa_verified_success"] == 3
+    assert agg["waa_verified_success_rate"] == 1.0
+    assert agg["total_model_calls"] == 0
+    assert agg["num_halted"] == 0
+
+
+def test_no_openadapt_flow_import_during_mocked_run(tmp_path):
+    b = tmp_path / "b"
+    b.mkdir()
+    run_demonstrate_then_replay(
+        [FlowTask("t", bundle_dir=b)], "http://x", tmp_path / "r",
+        replay_fn=lambda *a: _fake_report(),
+    )
+    assert "openadapt_flow" not in sys.modules

--- a/tests/test_flow_waa_cost.py
+++ b/tests/test_flow_waa_cost.py
@@ -1,0 +1,112 @@
+"""Tests for the flow-on-WAA cost model + hard guardrails.
+
+Stdlib-only path: none of these import openadapt_flow or require a VM.
+"""
+
+import sys
+
+import pytest
+
+from openadapt_evals.flow.cost import (
+    BILLING_ABORT_AFTER,
+    MODELS,
+    CostGuardConfig,
+    SpendLedger,
+    claude_image_tokens,
+    cost_per_step_usd,
+    estimate_flow_waa_cost,
+    looks_like_billing_error,
+    openai_image_tokens,
+)
+
+
+def test_importing_flow_package_does_not_pull_in_openadapt_flow():
+    """Heavy-import guard: importing the package/cost must not import flow."""
+    # Fresh import already happened at module load; assert flow stayed out.
+    import openadapt_evals.flow  # noqa: F401
+
+    assert "openadapt_flow" not in sys.modules
+
+
+def test_image_token_formulas_match_known_values():
+    # 1920x1080 -> Claude ~1844, OpenAI 1105 (from waa_cost_estimate docstring).
+    assert claude_image_tokens(1920, 1080) == 1843
+    assert openai_image_tokens(1920, 1080) == 1105
+
+
+def test_replay_mode_has_zero_token_cost():
+    est = estimate_flow_waa_cost(154, mode="replay")
+    assert est.token_cost_usd == 0.0
+    assert est.paid_tasks == 0.0
+    assert est.total_cost_usd == pytest.approx(est.vm_cost_usd)
+    # Replay must be far cheaper than the pure-agent baseline.
+    assert est.total_cost_usd < est.baseline_agent_cost_usd
+
+
+def test_hybrid_mode_pays_only_for_fallbacks():
+    full = estimate_flow_waa_cost(154, mode="hybrid", fallback_rate=1.0)
+    none = estimate_flow_waa_cost(154, mode="hybrid", fallback_rate=0.0)
+    half = estimate_flow_waa_cost(154, mode="hybrid", fallback_rate=0.5)
+    assert none.token_cost_usd == 0.0
+    assert half.token_cost_usd == pytest.approx(full.token_cost_usd * 0.5, rel=1e-6)
+    # Fallback pays fewer steps than the from-scratch baseline.
+    assert full.token_cost_usd < full.baseline_agent_cost_usd
+
+
+def test_cost_scales_with_num_tasks():
+    e10 = estimate_flow_waa_cost(10, mode="replay")
+    e154 = estimate_flow_waa_cost(154, mode="replay")
+    assert e154.total_cost_usd > e10.total_cost_usd
+
+
+def test_baseline_matches_manual_step_math():
+    est = estimate_flow_waa_cost(154, mode="replay", model_name="claude-sonnet-4")
+    step = cost_per_step_usd(MODELS["claude-sonnet-4"])
+    assert est.baseline_agent_cost_usd == pytest.approx(154 * 22 * step)
+
+
+def test_unknown_model_and_mode_raise():
+    with pytest.raises(ValueError):
+        estimate_flow_waa_cost(10, model_name="nope")
+    with pytest.raises(ValueError):
+        estimate_flow_waa_cost(10, mode="nope")
+
+
+# --- guardrails -----------------------------------------------------------
+
+
+def test_ledger_blocks_when_total_cap_would_be_exceeded():
+    ledger = SpendLedger(CostGuardConfig(per_run_usd=0.5, total_usd=1.0))
+    assert ledger.can_start()
+    ledger.record(0.6)
+    # 0.6 spent + 0.5 next cap = 1.1 > 1.0 ceiling -> blocked.
+    assert not ledger.can_start()
+    assert "ceiling" in ledger.blocked_reason()
+
+
+def test_ledger_aborts_after_consecutive_billing_errors():
+    ledger = SpendLedger(CostGuardConfig(total_usd=100.0))
+    for _ in range(BILLING_ABORT_AFTER):
+        ledger.record(0.0, error="Error 429: rate_limit exceeded")
+    assert ledger.aborted is not None
+    assert not ledger.can_start()
+
+
+def test_ledger_billing_error_streak_resets_on_success():
+    ledger = SpendLedger(CostGuardConfig(total_usd=100.0))
+    ledger.record(0.0, error="401 unauthorized")
+    ledger.record(0.01, error=None)  # a clean run resets the streak
+    ledger.record(0.0, error="429 too many requests")
+    assert ledger.aborted is None  # only one consecutive at the end
+
+
+def test_token_cap_detection():
+    ledger = SpendLedger(CostGuardConfig(per_task_tokens=1000))
+    assert not ledger.token_cap_exceeded(999)
+    assert ledger.token_cap_exceeded(1001)
+
+
+def test_looks_like_billing_error_markers():
+    assert looks_like_billing_error("HTTP 429 Too Many Requests")
+    assert looks_like_billing_error("insufficient_quota")
+    assert not looks_like_billing_error("element not found on screen")


### PR DESCRIPTION
## What

Wires **openadapt-flow** (the demonstration compiler) into the existing WAA benchmark harness so we can evaluate it on WindowsAgentArena. Two eval modes, both scored by **WAA's own task verifier** (not self-report). Ships the code + a cost model. **No Azure is provisioned and no money is spent** — everything here is mock/dry-run testable locally; the live run is gated on the maintainer's explicit go.

## Two eval modes

1. **Demonstrate-then-replay** (`openadapt_evals/flow/replay_runner.py`) — the paradigm-correct eval for a demonstration compiler. Compile ONE demo into a bundle and replay it via openadapt-flow's `WindowsBackend` against the WAA in-guest `/screenshot` + `/execute_windows` server (the SAME contract WAA exposes — no adapter layer). Per-task metrics: WAA-verified success, replay self-report, structural rung fire rate, model calls (~0 on healthy replay), wall-clock, halt/heal events.
2. **Hybrid-as-agent** (`openadapt_evals/flow/hybrid_agent.py`) — `HybridFlowAgent` implements `BenchmarkAgent`, so the existing `evaluate_agent_on_benchmark` runner drives it exactly like any agent. Compiled replay first; computer-use agent fallback **only on a detected halt**, gated by a shared `SpendLedger`. Directly comparable to a pure agent baseline on the same tasks / same verifier.

## Cost model + hard guardrails

`openadapt_evals/flow/cost.py` (stdlib-only, no flow/VM/key needed): estimates $ for N tasks (Azure VM-hours + agent-arm token cost) and enforces a **per-run $ cap, total $ ceiling, per-task token cap, and abort-on-repeated-billing-error** — mirroring openadapt-flow's benchmark `SpendLedger` (the prior $40-70 uncapped-run incident is why these are mandatory).

`scripts/eval_flow_on_waa.py` is **dry-run by default** — prints the plan + cost and never provisions Azure/starts a VM/spends money. `scripts/waa_cost_estimate.py` gains a flow-aware `--tasks/--mode/--dry-run` path (legacy table unchanged with no args).

### Estimated cost (Claude Sonnet 4, $0.19/hr VM)

| Mode | 10 tasks | 154 tasks | Pure-agent baseline (154) |
|---|---|---|---|
| replay | ~$0.08 | ~$0.54 (VM only, $0 tokens) | ~$39 |
| hybrid @30% fallback | — | ~$6.15 (VM + $5.33 tokens) | ~$39 |

(The $6.15 hybrid@154 case trips the default $5 total cap — the guard prints a WARNING and a `--live` run is refused until the cap is raised.)

## Runnable now vs. needs Azure + $

- **Runnable now (mock/dry-run, this PR's tests):** cost model, guardrails, both runners with injected fakes, and `--dry-run` plan/estimate. 30 new tests, zero Azure, zero VM, zero flow dependency.
- **Needs Azure + $ + revived `waa-pool`:** the actual replay/hybrid execution — `oa-vm pool-create` / `pool-wait`, compiled bundles per task, then `--live`. Gated behind `--live` + a reachable server; refuses on missing bundles before any network call.

## Dependency note

`openadapt-flow` is added as an optional `[flow]` extra (on PyPI, 0.20.0). All replay/hybrid code lazy-imports it. `openadapt_flow.backends.win_agent` (PR #95, still open) is **not** required for the WAA path — WAA already exposes the same in-guest server contract that `WindowsBackend` targets. Verified at API level against the real flow package (WindowsBackend `server_url`, `RunReport` fields) without a VM.

## Tests

`tests/test_flow_waa_cost.py`, `tests/test_flow_replay_runner.py`, `tests/test_flow_hybrid_agent.py`, `tests/test_eval_flow_on_waa_dryrun.py` — 30 passing, fully mocked. Existing WAA/mock/cost suites (113 tests) still green; ruff clean on all new/modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ
