### PR TITLE
feat: lightweight meta-benchmark harness (unify Environment/verify + metrics; OSWorld/BrowserGym stubs for phase 2)

### DIFF
--- a/openadapt_evals/harness/__init__.py
+++ b/openadapt_evals/harness/__init__.py
@@ -1,0 +1,137 @@
+"""Lightweight meta-benchmark harness: ONE ``Environment`` + ONE metrics row.
+
+A **consolidation over existing openadapt-evals code**, not new infrastructure
+and not an external harness. It unifies the repo's three parallel abstractions
+-- ``BenchmarkAdapter`` (adapters), ``TaskVerifierRegistry`` (evaluation), and
+the flow ``EffectVerifier`` -- behind a single
+:class:`~openadapt_evals.harness.protocol.Environment` protocol whose
+:meth:`~openadapt_evals.harness.protocol.Environment.verify` folds all three
+scoring paths into one call, and drives them with one
+:func:`~openadapt_evals.harness.runner.run_meta` that emits one JSONL metrics
+row per ``(env, task, mode)``.
+
+Surface:
+
+- Protocol + task: :class:`Environment`, :class:`MetaTask`, :class:`Observation`,
+  :class:`VerificationResult`.
+- Conforming shims over existing adapters:
+  :class:`BenchmarkAdapterEnvironment` (WAA live/mock, Local),
+  :class:`MockMedAdapter`, :class:`OpenEMRAdapter`.
+- Runner + policies: :func:`run_meta`, :func:`run_meta_suite`,
+  :class:`MetaMetricsRow`, :class:`PolicyOutcome`, :func:`make_replay_policy`,
+  :func:`make_hybrid_policy`, :func:`make_agent_policy`.
+- Inspect eval-log export: :func:`to_inspect_eval_log`,
+  :func:`from_inspect_eval_log`, :func:`write_inspect_eval_log`.
+- Phase-2 stubs (NotImplementedError): :class:`OSWorldAdapter`,
+  :class:`BrowserGymAdapter`.
+
+Submodules are imported lazily (PEP 562) so importing this package never pulls
+in ``openadapt_flow``, a browser, or a VM.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+__all__ = [
+    # protocol
+    "Environment",
+    "MetaTask",
+    "Observation",
+    "VerificationResult",
+    # adapters (conforming shims)
+    "BenchmarkAdapterEnvironment",
+    "MockMedAdapter",
+    "OpenEMRAdapter",
+    # runner + policies
+    "run_meta",
+    "run_meta_suite",
+    "MetaMetricsRow",
+    "PolicyOutcome",
+    "make_replay_policy",
+    "make_hybrid_policy",
+    "make_agent_policy",
+    # inspect export
+    "to_inspect_eval_log",
+    "from_inspect_eval_log",
+    "write_inspect_eval_log",
+    # phase-2 stubs
+    "OSWorldAdapter",
+    "BrowserGymAdapter",
+]
+
+_EXPORTS = {
+    "Environment": ("openadapt_evals.harness.protocol", "Environment"),
+    "MetaTask": ("openadapt_evals.harness.protocol", "MetaTask"),
+    "Observation": ("openadapt_evals.harness.protocol", "Observation"),
+    "VerificationResult": ("openadapt_evals.harness.protocol", "VerificationResult"),
+    "BenchmarkAdapterEnvironment": (
+        "openadapt_evals.harness.adapters",
+        "BenchmarkAdapterEnvironment",
+    ),
+    "MockMedAdapter": ("openadapt_evals.harness.adapters", "MockMedAdapter"),
+    "OpenEMRAdapter": ("openadapt_evals.harness.adapters", "OpenEMRAdapter"),
+    "run_meta": ("openadapt_evals.harness.runner", "run_meta"),
+    "run_meta_suite": ("openadapt_evals.harness.runner", "run_meta_suite"),
+    "MetaMetricsRow": ("openadapt_evals.harness.runner", "MetaMetricsRow"),
+    "PolicyOutcome": ("openadapt_evals.harness.runner", "PolicyOutcome"),
+    "make_replay_policy": ("openadapt_evals.harness.runner", "make_replay_policy"),
+    "make_hybrid_policy": ("openadapt_evals.harness.runner", "make_hybrid_policy"),
+    "make_agent_policy": ("openadapt_evals.harness.runner", "make_agent_policy"),
+    "to_inspect_eval_log": (
+        "openadapt_evals.harness.inspect_export",
+        "to_inspect_eval_log",
+    ),
+    "from_inspect_eval_log": (
+        "openadapt_evals.harness.inspect_export",
+        "from_inspect_eval_log",
+    ),
+    "write_inspect_eval_log": (
+        "openadapt_evals.harness.inspect_export",
+        "write_inspect_eval_log",
+    ),
+    "OSWorldAdapter": ("openadapt_evals.harness.external", "OSWorldAdapter"),
+    "BrowserGymAdapter": ("openadapt_evals.harness.external", "BrowserGymAdapter"),
+}
+
+if TYPE_CHECKING:  # pragma: no cover
+    from openadapt_evals.harness.adapters import (
+        BenchmarkAdapterEnvironment,
+        MockMedAdapter,
+        OpenEMRAdapter,
+    )
+    from openadapt_evals.harness.external import BrowserGymAdapter, OSWorldAdapter
+    from openadapt_evals.harness.inspect_export import (
+        from_inspect_eval_log,
+        to_inspect_eval_log,
+        write_inspect_eval_log,
+    )
+    from openadapt_evals.harness.protocol import (
+        Environment,
+        MetaTask,
+        Observation,
+        VerificationResult,
+    )
+    from openadapt_evals.harness.runner import (
+        MetaMetricsRow,
+        PolicyOutcome,
+        make_agent_policy,
+        make_hybrid_policy,
+        make_replay_policy,
+        run_meta,
+        run_meta_suite,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    target = _EXPORTS.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    module = importlib.import_module(target[0])
+    return getattr(module, target[1])
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/openadapt_evals/harness/adapters.py
+++ b/openadapt_evals/harness/adapters.py
@@ -1,0 +1,409 @@
+"""Thin shims that make the EXISTING adapters satisfy :class:`Environment`.
+
+Nothing here re-implements an environment. Each shim is a mechanical wrapper
+that (a) forwards ``reset`` / ``observe`` / ``act`` / ``close`` to an existing
+adapter and (b) folds that family's native scoring -- ``BenchmarkAdapter.
+evaluate`` + :class:`TaskVerifierRegistry`, or a flow ``EffectVerifier`` -- into
+the single :meth:`Environment.verify` entry point.
+
+Three conform today:
+
+- :class:`BenchmarkAdapterEnvironment` -- wraps ANY
+  :class:`~openadapt_evals.adapters.base.BenchmarkAdapter` (so ``WAAAdapter``,
+  ``WAALiveAdapter``, ``WAAMockAdapter``, ``LocalAdapter`` all conform). Its
+  ``verify`` prefers a registered :class:`TaskVerifierRegistry` verifier when
+  ``task.verifier`` is set and falls back to the adapter's native
+  ``evaluate``.
+- :class:`MockMedAdapter` -- the MockMed fault server scored by the flow
+  ``RestRecordVerifier`` (JSON system of record at ``/api/db``).
+- :class:`OpenEMRAdapter` -- OpenEMR scored by the flow ``FhirEffectVerifier``
+  (FHIR R4 system of record).
+
+Everything heavy (``openadapt_flow``, a live browser, a live VM) is imported
+lazily and every collaborator is injectable, so the shims are unit-testable
+with fakes -- no flow extra, no VM, no browser, no network.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional
+
+from openadapt_types import (
+    BenchmarkAction,
+    BenchmarkObservation,
+    BenchmarkTask,
+)
+
+from openadapt_evals.evaluation.verifier_registry import (
+    TaskVerifierRegistry,
+    VerificationResult,
+    registry as global_registry,
+)
+from openadapt_evals.harness.protocol import Observation
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# 1. Any BenchmarkAdapter -> Environment (WAA live/mock, Local, ...).
+# ---------------------------------------------------------------------------
+
+
+class BenchmarkAdapterEnvironment:
+    """Adapt any :class:`BenchmarkAdapter` to the :class:`Environment` protocol.
+
+    The mechanical shim from the trichotomy's adapter leg to the unified
+    protocol. ``reset`` / ``act`` / ``close`` forward straight through;
+    ``observe`` uses the adapter's own ``observe`` when it has one (the live/
+    local adapters do) and otherwise replays the last observation captured from
+    ``reset`` / ``act``.
+
+    ``verify`` is the unification: it prefers a :class:`TaskVerifierRegistry`
+    verifier (when ``task.verifier`` names one) and falls back to the adapter's
+    native ``evaluate`` -- folding both legacy scoring paths into one call that
+    always yields a :class:`VerificationResult`.
+
+    Args:
+        adapter: The wrapped ``BenchmarkAdapter``.
+        env_name: Family label recorded on metrics rows (default: adapter.name).
+        verifier_registry: Registry consulted by ``verify`` (default: the global
+            registry, so built-in verifiers are available).
+    """
+
+    def __init__(
+        self,
+        adapter: Any,
+        *,
+        env_name: Optional[str] = None,
+        verifier_registry: Optional[TaskVerifierRegistry] = None,
+    ) -> None:
+        self._adapter = adapter
+        self._env_name = env_name or getattr(adapter, "name", "adapter")
+        self._registry = (
+            verifier_registry if verifier_registry is not None else global_registry
+        )
+        self._last_obs: Optional[BenchmarkObservation] = None
+
+    @property
+    def name(self) -> str:
+        return self._env_name
+
+    @property
+    def adapter(self) -> Any:
+        return self._adapter
+
+    def reset(self, task: BenchmarkTask) -> Observation:
+        self._last_obs = self._adapter.reset(task)
+        return self._last_obs
+
+    def observe(self) -> Observation:
+        observe = getattr(self._adapter, "observe", None)
+        if callable(observe):
+            self._last_obs = observe()
+            return self._last_obs
+        if self._last_obs is None:
+            raise RuntimeError(
+                "no observation available: call reset() before observe(), or "
+                "wrap an adapter that exposes observe()"
+            )
+        return self._last_obs
+
+    def act(
+        self, action: BenchmarkAction
+    ) -> "tuple[Observation, bool, dict[str, Any]]":
+        obs, done, info = self._adapter.step(action)
+        self._last_obs = obs
+        return obs, done, info
+
+    def verify(self, task: BenchmarkTask) -> VerificationResult:
+        """Unified scoring: registry verifier first, native ``evaluate`` fallback."""
+        key = getattr(task, "verifier", None)
+        if key and self._registry is not None and self._registry.has_verifier(key):
+            result = self._registry.verify(key, self._adapter)
+            result.details.setdefault("source", "verifier_registry")
+            result.details.setdefault("verifier_key", key)
+            return result
+
+        # Fall back to the benchmark's own execution-based evaluator.
+        result = self._adapter.evaluate(task)
+        return VerificationResult(
+            success=bool(getattr(result, "success", False)),
+            score=float(getattr(result, "score", 0.0) or 0.0),
+            details={
+                "source": "adapter.evaluate",
+                "reason": getattr(result, "reason", None),
+                "num_steps": getattr(result, "num_steps", None),
+            },
+        )
+
+    def close(self) -> None:
+        close = getattr(self._adapter, "close", None)
+        if callable(close):
+            close()
+
+
+# ---------------------------------------------------------------------------
+# 2. Effect-verified web environments (MockMed, OpenEMR) via openadapt-flow.
+# ---------------------------------------------------------------------------
+
+# A verdict->result mapping shared by both web envs.
+def _verdict_to_result(verdict: Any) -> VerificationResult:
+    """Convert a flow ``EffectVerdict`` into a :class:`VerificationResult`.
+
+    CONFIRMED -> success (score 1.0); REFUTED / INDETERMINATE -> failure
+    (score 0.0). The three-valued verdict string is preserved in ``details``
+    (``effect_verdict``) so the metrics row can distinguish "wrong write"
+    (REFUTED) from "could not tell" (INDETERMINATE) -- the whole point of the
+    effect-verification wedge.
+    """
+    verdict_str = getattr(getattr(verdict, "verdict", None), "value", None) or str(
+        getattr(verdict, "verdict", "")
+    )
+    confirmed = bool(getattr(verdict, "confirmed", False))
+    return VerificationResult(
+        success=confirmed,
+        score=1.0 if confirmed else 0.0,
+        details={
+            "source": "effect_verifier",
+            "effect_verdict": verdict_str,
+            "substrate": getattr(verdict, "substrate", ""),
+            "reason": getattr(verdict, "reason", ""),
+            "observed_count": getattr(verdict, "observed_count", None),
+            "expected_count": getattr(verdict, "expected_count", None),
+        },
+    )
+
+
+class _EffectVerifiedWebEnvironment:
+    """Base for a Playwright-driven web env scored by a flow ``EffectVerifier``.
+
+    Wraps the flow-side Playwright ``Backend`` (drives the page) and an
+    ``EffectVerifier`` (reads the REAL system of record, never the screen).
+    ``reset`` snapshots the pre-action system-of-record state; ``verify`` builds
+    the task's :class:`Effect` and asks the verifier to rule on it.
+
+    Both the backend and the verifier are injectable so this is testable with
+    fakes; the real ones are built lazily from ``openadapt_flow`` only when not
+    supplied. ``effect_builder`` maps a task to an ``Effect`` (default: validate
+    ``task.evaluation_spec`` into an ``Effect`` -- bare-string selectors are
+    coerced to ``ValueExpr`` by the flow model, matching v1 bundles).
+    """
+
+    substrate = "effect"
+
+    def __init__(
+        self,
+        *,
+        backend: Any = None,
+        verifier: Any = None,
+        effect_builder: Optional[Callable[[BenchmarkTask], Any]] = None,
+    ) -> None:
+        self._backend = backend
+        self._verifier = verifier
+        self._effect_builder = effect_builder or _default_effect_builder
+        self._pre_state: Any = None
+        self._last_obs: Optional[BenchmarkObservation] = None
+
+    # -- lazy real collaborators (subclasses override _build_verifier) -------
+
+    def _build_backend(self) -> Any:  # pragma: no cover - requires a live browser
+        raise ImportError(
+            "no backend supplied and no live Playwright backend configured; "
+            "inject `backend=` (tests) or install 'openadapt-evals[flow]' and "
+            "pass a launched PlaywrightBackend"
+        )
+
+    def _build_verifier(self) -> Any:  # pragma: no cover - subclass responsibility
+        raise NotImplementedError
+
+    @property
+    def backend(self) -> Any:
+        if self._backend is None:
+            self._backend = self._build_backend()
+        return self._backend
+
+    @property
+    def verifier(self) -> Any:
+        if self._verifier is None:
+            self._verifier = self._build_verifier()
+        return self._verifier
+
+    # -- Environment ---------------------------------------------------------
+
+    def reset(self, task: BenchmarkTask) -> Observation:
+        # Snapshot the system of record BEFORE the workflow runs so the verifier
+        # can count only records this run wrote (delta / at-most-once).
+        capture = getattr(self.verifier, "capture_pre_state", None)
+        self._pre_state = capture() if callable(capture) else None
+        self._last_obs = self.observe()
+        return self._last_obs
+
+    def observe(self) -> Observation:
+        backend = self.backend
+        screenshot = None
+        shot = getattr(backend, "screenshot", None)
+        if callable(shot):
+            try:
+                screenshot = shot()
+            except Exception:  # noqa: BLE001 - observation is best-effort
+                screenshot = None
+        self._last_obs = BenchmarkObservation(
+            screenshot=screenshot,
+            viewport=getattr(backend, "viewport", None),
+            url=getattr(backend, "url", None),
+            window_title=getattr(backend, "page_title", None),
+            raw_observation={"substrate": self.substrate},
+        )
+        return self._last_obs
+
+    def act(
+        self, action: BenchmarkAction
+    ) -> "tuple[Observation, bool, dict[str, Any]]":
+        """Translate a canonical action into a Playwright backend call."""
+        backend = self.backend
+        done = False
+        if action.type in ("click", "double_click"):
+            backend.click(
+                int(action.x or 0),
+                int(action.y or 0),
+                double=action.type == "double_click",
+            )
+        elif action.type == "type":
+            backend.type_text(action.text or "")
+        elif action.type == "key":
+            key = action.key or ""
+            if action.modifiers:
+                key = "+".join([*action.modifiers, key])
+            backend.press(key)
+        elif action.type == "scroll":
+            amount = int(action.scroll_amount or 3)
+            dy = amount if action.scroll_direction != "up" else -amount
+            backend.scroll(0, dy)
+        elif action.type in ("done", "answer"):
+            done = True
+        obs = self.observe()
+        return obs, done, {"action_type": action.type}
+
+    def verify(self, task: BenchmarkTask) -> VerificationResult:
+        """Rule on the task's effect against the REAL system of record."""
+        expected = self._effect_builder(task)
+        verdict = self.verifier.verify(expected, self._pre_state)
+        return _verdict_to_result(verdict)
+
+    def close(self) -> None:
+        close = getattr(self._backend, "close", None)
+        if callable(close):
+            close()
+
+
+def _default_effect_builder(task: BenchmarkTask) -> Any:
+    """Build a flow ``Effect`` from ``task.evaluation_spec`` (lazy import).
+
+    The spec is the RFC ``Effect`` payload
+    (e.g. ``{"kind": "record_written", "match": {"patient_id": "p1"}}``). Bare
+    string selector values are coerced to ``ValueExpr`` by the flow model.
+    """
+    spec = getattr(task, "evaluation_spec", None)
+    if not spec:
+        raise ValueError(
+            f"task {getattr(task, 'task_id', '?')!r} has no evaluation_spec to "
+            "build an Effect from; set evaluation_spec or pass effect_builder="
+        )
+    from openadapt_flow.runtime.effects import Effect  # lazy: heavy
+
+    return Effect.model_validate(spec)
+
+
+class MockMedAdapter(_EffectVerifiedWebEnvironment):
+    """MockMed (the flow reference clinic app + ``fault_server``) as an env.
+
+    Scored by the flow :class:`RestRecordVerifier` against MockMed's JSON system
+    of record (default ``/api/db``, records under the ``records`` key). The
+    ``fault_server`` injects the transactional faults (phantom / partial /
+    duplicate / lost-update) whose silent mishandling is exactly what the effect
+    verifier catches.
+
+    Args:
+        base_url: MockMed base URL (e.g. ``http://localhost:8000``).
+        records_path: System-of-record document path (default ``/api/db``).
+        backend / verifier / effect_builder: Injectable for tests; real ones
+            built lazily from ``openadapt_flow``.
+    """
+
+    substrate = "rest"
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8000",
+        *,
+        records_path: str = "/api/db",
+        backend: Any = None,
+        verifier: Any = None,
+        effect_builder: Optional[Callable[[BenchmarkTask], Any]] = None,
+    ) -> None:
+        super().__init__(
+            backend=backend, verifier=verifier, effect_builder=effect_builder
+        )
+        self._base_url = base_url
+        self._records_path = records_path
+
+    def _build_verifier(self) -> Any:  # pragma: no cover - needs flow extra
+        from openadapt_flow.runtime.effects import RestRecordVerifier
+
+        return RestRecordVerifier(self._base_url, records_path=self._records_path)
+
+
+class OpenEMRAdapter(_EffectVerifiedWebEnvironment):
+    """OpenEMR (the flagship real EMR) as an env.
+
+    Scored by the flow :class:`FhirEffectVerifier` against OpenEMR's FHIR R4 API
+    -- the primary, real-EMR system of record from the OpenEMR flagship
+    benchmark. (An OCR fallback verifier can be swapped in via ``verifier=`` when
+    FHIR is unavailable; FHIR is the default and primary.)
+
+    Args:
+        base_url: OpenEMR FHIR base URL (e.g. ``https://host/apis/default/fhir``).
+        resource_type: FHIR resource searched (default ``Observation``).
+        access_token: OAuth2 bearer token for the FHIR API.
+        backend / verifier / effect_builder: Injectable for tests; real ones
+            built lazily from ``openadapt_flow``.
+    """
+
+    substrate = "fhir"
+
+    def __init__(
+        self,
+        base_url: str = "http://localhost/apis/default/fhir",
+        *,
+        resource_type: str = "Observation",
+        access_token: Optional[str] = None,
+        search_params: Optional[dict] = None,
+        backend: Any = None,
+        verifier: Any = None,
+        effect_builder: Optional[Callable[[BenchmarkTask], Any]] = None,
+    ) -> None:
+        super().__init__(
+            backend=backend, verifier=verifier, effect_builder=effect_builder
+        )
+        self._base_url = base_url
+        self._resource_type = resource_type
+        self._access_token = access_token
+        self._search_params = search_params
+
+    def _build_verifier(self) -> Any:  # pragma: no cover - needs flow extra
+        from openadapt_flow.runtime.effects import FhirEffectVerifier
+
+        return FhirEffectVerifier(
+            self._base_url,
+            resource_type=self._resource_type,
+            search_params=self._search_params,
+            access_token=self._access_token,
+        )
+
+
+__all__ = [
+    "BenchmarkAdapterEnvironment",
+    "MockMedAdapter",
+    "OpenEMRAdapter",
+]

--- a/openadapt_evals/harness/external.py
+++ b/openadapt_evals/harness/external.py
@@ -1,0 +1,111 @@
+"""Phase-2 stubs for external interactive benchmarks (OSWorld, BrowserGym).
+
+These are **interface skeletons only** -- deliberately unimplemented. Phase 1
+consolidates the OpenAdapt-native families (WAA, Parallels, MockMed, OpenEMR)
+behind :class:`~openadapt_evals.harness.protocol.Environment`. Phase 2 wires two
+external suites into the SAME protocol, reusing their NATIVE execution verifiers
+(the whole reason to adopt them: real, community-maintained task graders) --
+never re-scoring with our own.
+
+Nothing here installs or imports OSWorld / BrowserGym. Each method raises
+:class:`NotImplementedError` with the concrete phase-2 wiring plan so the shape
+of the work is captured without pulling the dependencies into phase 1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openadapt_types import BenchmarkAction, BenchmarkTask
+
+from openadapt_evals.harness.protocol import Observation, VerificationResult
+
+_PHASE2 = "phase 2: not implemented in the lightweight meta-benchmark (phase 1)"
+
+
+class OSWorldAdapter:
+    """STUB -- OSWorld (Ubuntu desktop, 369 tasks) as an :class:`Environment`.
+
+    Phase-2 wiring plan:
+
+    - ``reset`` boots OSWorld's ``DesktopEnv`` VM to the task's snapshot and
+      returns its screenshot + a11y observation (map into
+      :class:`~openadapt_types.BenchmarkObservation`).
+    - ``act`` translates a canonical :class:`~openadapt_types.BenchmarkAction`
+      into OSWorld's ``pyautogui``-style action and steps the env.
+    - ``verify`` delegates to OSWorld's NATIVE ``env.evaluate()`` -- each task
+      ships a ``getter`` + a ``metric`` function that inspects real machine
+      state (files, configs, command output). Map its ``[0, 1]`` reward into a
+      :class:`VerificationResult` (``success = reward >= 1.0``). We do NOT
+      substitute our own scoring: the point of adopting OSWorld is its curated
+      execution verifiers.
+    - Heavy (a VM per task); build lazily, keep injectable/mockable exactly like
+      the WAA + Parallels envs.
+
+    Do NOT install OSWorld in phase 1.
+    """
+
+    name = "osworld"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_PHASE2)
+
+    def reset(self, task: BenchmarkTask) -> Observation:
+        raise NotImplementedError(_PHASE2)
+
+    def observe(self) -> Observation:
+        raise NotImplementedError(_PHASE2)
+
+    def act(self, action: BenchmarkAction) -> "tuple[Observation, bool, dict[str, Any]]":
+        raise NotImplementedError(_PHASE2)
+
+    def verify(self, task: BenchmarkTask) -> VerificationResult:
+        raise NotImplementedError(_PHASE2)
+
+    def close(self) -> None:
+        raise NotImplementedError(_PHASE2)
+
+
+class BrowserGymAdapter:
+    """STUB -- BrowserGym (WebArena/MiniWoB/WorkArena) as an :class:`Environment`.
+
+    Phase-2 wiring plan:
+
+    - ``reset`` creates the BrowserGym ``gym.make("browsergym/<task>")`` env and
+      returns its observation (screenshot + AXTree + DOM) mapped into
+      :class:`~openadapt_types.BenchmarkObservation`.
+    - ``act`` renders a canonical action into BrowserGym's high-level action
+      string (e.g. ``click(bid)`` / ``fill(bid, text)``) and steps the env.
+    - ``verify`` delegates to BrowserGym's NATIVE per-task reward: the underlying
+      WebArena/WorkArena validators return terminal reward ``1.0`` on success.
+      Read the last ``step`` reward (or call the task's validator) and map into a
+      :class:`VerificationResult`. As with OSWorld, we reuse the suite's own
+      execution verifier rather than re-grading.
+    - Reuse the flow ``PlaywrightBackend`` where a raw browser is preferable to
+      the gym wrapper; keep the env lazy + mockable.
+
+    Do NOT install BrowserGym in phase 1.
+    """
+
+    name = "browsergym"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(_PHASE2)
+
+    def reset(self, task: BenchmarkTask) -> Observation:
+        raise NotImplementedError(_PHASE2)
+
+    def observe(self) -> Observation:
+        raise NotImplementedError(_PHASE2)
+
+    def act(self, action: BenchmarkAction) -> "tuple[Observation, bool, dict[str, Any]]":
+        raise NotImplementedError(_PHASE2)
+
+    def verify(self, task: BenchmarkTask) -> VerificationResult:
+        raise NotImplementedError(_PHASE2)
+
+    def close(self) -> None:
+        raise NotImplementedError(_PHASE2)
+
+
+__all__ = ["OSWorldAdapter", "BrowserGymAdapter"]

--- a/openadapt_evals/harness/inspect_export.py
+++ b/openadapt_evals/harness/inspect_export.py
@@ -1,0 +1,172 @@
+"""Serialize meta-benchmark rows to an Inspect eval-log (``.eval``) JSON.
+
+Inspect (the UK AISI eval framework, ``inspect_ai``) has a widely-used log
+viewer + leaderboard. This module makes a meta-benchmark run PORTABLE to that
+ecosystem by writing a subset of the Inspect eval-log schema -- WITHOUT adopting
+Inspect as the runtime (no ``inspect_ai`` dependency, no Inspect ``Task`` /
+``Solver`` / ``Scorer``). We keep our own :class:`Environment` + :func:`run_meta`
+runtime and only borrow the log format on the way out.
+
+The emitted document is a plain dict (JSON-serializable). Each meta row becomes
+one Inspect ``sample`` with a boolean-mapped score (``"C"`` correct / ``"I"``
+incorrect) and our full row under ``metadata`` so the round-trip is lossless.
+:func:`from_inspect_eval_log` reconstructs the rows for tests / re-import.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Inspect's canonical value for a correct/incorrect boolean score.
+_CORRECT = "C"
+_INCORRECT = "I"
+
+_SCHEMA_VERSION = 2  # Inspect eval-log major version this subset targets.
+
+
+def _row_to_dict(row: Any) -> dict:
+    if is_dataclass(row) and not isinstance(row, type):
+        as_dict = getattr(row, "as_dict", None)
+        return as_dict() if callable(as_dict) else asdict(row)
+    if isinstance(row, dict):
+        return dict(row)
+    raise TypeError(f"cannot serialize row of type {type(row).__name__}")
+
+
+def to_inspect_eval_log(
+    rows: "list[Any]",
+    *,
+    task_name: str = "openadapt-meta-benchmark",
+    model: str = "openadapt-flow/compiled",
+    created: str | None = None,
+) -> dict:
+    """Build an Inspect eval-log dict from meta-benchmark rows.
+
+    Args:
+        rows: :class:`MetaMetricsRow` objects (or their dicts).
+        task_name: Inspect ``eval.task`` name.
+        model: Inspect ``eval.model`` label.
+        created: ISO timestamp (defaults to now, UTC).
+
+    Returns:
+        A dict conforming to the Inspect eval-log subset. Serialize with
+        :func:`json.dumps` or :func:`write_inspect_eval_log`.
+    """
+    created = created or datetime.now(timezone.utc).isoformat()
+    dict_rows = [_row_to_dict(r) for r in rows]
+
+    samples = []
+    for i, r in enumerate(dict_rows):
+        success = bool(r.get("replay_success", False))
+        samples.append(
+            {
+                "id": r.get("task_id", f"sample_{i}"),
+                "epoch": 1,
+                "input": r.get("task_id", ""),
+                "target": _CORRECT,
+                "scores": {
+                    "meta_verifier": {
+                        "value": _CORRECT if success else _INCORRECT,
+                        "answer": str(r.get("effect_verdict") or r.get("verifier_source") or ""),
+                        "explanation": r.get("error") or "",
+                        "metadata": {
+                            "env": r.get("env"),
+                            "mode": r.get("mode"),
+                            "model_calls": r.get("model_calls"),
+                            "structural_rung_rate": r.get("structural_rung_rate"),
+                            "wall_ms": r.get("wall_ms"),
+                            "cost_usd": r.get("cost_usd"),
+                        },
+                    }
+                },
+                # Full lossless row so from_inspect_eval_log round-trips.
+                "metadata": r,
+            }
+        )
+
+    total = len(samples)
+    correct = sum(1 for s in samples if s["scores"]["meta_verifier"]["value"] == _CORRECT)
+
+    return {
+        "version": _SCHEMA_VERSION,
+        "status": "success",
+        "eval": {
+            "task": task_name,
+            "model": model,
+            "created": created,
+            "dataset": {"name": task_name, "samples": total},
+        },
+        "results": {
+            "total_samples": total,
+            "completed_samples": total,
+            "scores": [
+                {
+                    "name": "meta_verifier",
+                    "scorer": "meta_verifier",
+                    "metrics": {
+                        "accuracy": {
+                            "name": "accuracy",
+                            "value": (correct / total) if total else 0.0,
+                        }
+                    },
+                }
+            ],
+        },
+        "samples": samples,
+    }
+
+
+def from_inspect_eval_log(doc: dict) -> "list[dict]":
+    """Reconstruct meta-benchmark row dicts from an Inspect eval-log dict.
+
+    Prefers the lossless ``metadata`` payload written by
+    :func:`to_inspect_eval_log`; falls back to reconstructing from the score
+    value + score metadata for logs produced elsewhere.
+    """
+    rows: list[dict] = []
+    for sample in doc.get("samples", []):
+        meta = sample.get("metadata")
+        if isinstance(meta, dict) and "replay_success" in meta:
+            rows.append(dict(meta))
+            continue
+        score = sample.get("scores", {}).get("meta_verifier", {})
+        smeta = score.get("metadata", {})
+        rows.append(
+            {
+                "task_id": sample.get("id"),
+                "env": smeta.get("env"),
+                "mode": smeta.get("mode"),
+                "replay_success": score.get("value") == _CORRECT,
+                "effect_verdict": score.get("answer") or None,
+                "model_calls": smeta.get("model_calls"),
+                "structural_rung_rate": smeta.get("structural_rung_rate"),
+                "wall_ms": smeta.get("wall_ms"),
+                "cost_usd": smeta.get("cost_usd"),
+                "error": score.get("explanation") or None,
+            }
+        )
+    return rows
+
+
+def write_inspect_eval_log(rows: "list[Any]", path: Path | str, **kwargs: Any) -> Path:
+    """Write rows to ``path`` as Inspect eval-log JSON; return the path.
+
+    ``.eval`` files are ZIP archives in Inspect proper; this writes the JSON
+    document (``.eval.json`` recommended) that the log tooling also reads.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = to_inspect_eval_log(rows, **kwargs)
+    path.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+    return path
+
+
+__all__ = [
+    "to_inspect_eval_log",
+    "from_inspect_eval_log",
+    "write_inspect_eval_log",
+]

--- a/openadapt_evals/harness/protocol.py
+++ b/openadapt_evals/harness/protocol.py
@@ -1,0 +1,153 @@
+"""The unified ``Environment`` protocol for the lightweight meta-benchmark.
+
+This is a **consolidation over existing code**, not new infrastructure. The
+repo already has three parallel abstractions:
+
+- :class:`openadapt_evals.adapters.base.BenchmarkAdapter` -- ``list_tasks`` /
+  ``load_task`` / ``reset`` / ``step`` / ``evaluate`` (WAA, mock, local, ...).
+- :class:`openadapt_evals.evaluation.verifier_registry.TaskVerifierRegistry` --
+  declaratively-registered task verifiers returning
+  :class:`~openadapt_evals.evaluation.verifier_registry.VerificationResult`.
+- The flow-side ``EffectVerifier`` protocol (openadapt-flow) that rules
+  CONFIRMED / REFUTED / INDETERMINATE against a real system of record.
+
+Each benchmark family scores success a DIFFERENT way (WAA's native evaluator,
+a registry verifier reading VM state, an effect verifier reading a FHIR/REST
+system of record). The meta-benchmark needs ONE way to ask "did this task
+actually succeed?" regardless of family. :class:`Environment` provides that:
+its :meth:`~Environment.verify` is the single entry point that folds
+``BenchmarkAdapter.evaluate`` + ``TaskVerifierRegistry`` + ``EffectVerifier``
+into one call that always returns a :class:`VerificationResult`.
+
+Nothing here is heavy: it imports only the dependency-free canonical types from
+``openadapt-types`` and the stdlib. ``runtime_checkable`` lets the runner (and
+the tests) assert that any adapter/env conforms structurally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+# Reuse the canonical, dependency-free schema (openadapt-types). No new types.
+from openadapt_types import (
+    BenchmarkAction,
+    BenchmarkObservation,
+    BenchmarkTask,
+)
+
+# Reuse the existing verification result -- do NOT define a parallel one.
+from openadapt_evals.evaluation.verifier_registry import VerificationResult
+
+#: An observation is exactly the canonical benchmark observation. Aliased so the
+#: protocol reads in the meta-benchmark's own vocabulary.
+Observation = BenchmarkObservation
+
+__all__ = [
+    "Environment",
+    "Observation",
+    "MetaTask",
+    "VerificationResult",
+    "BenchmarkAction",
+    "BenchmarkObservation",
+    "BenchmarkTask",
+]
+
+
+@dataclass
+class MetaTask(BenchmarkTask):
+    """A :class:`~openadapt_types.BenchmarkTask` extended for the meta-benchmark.
+
+    Extends (never replaces) the canonical task with the three fields the
+    meta-runner needs to drive record->compile->replay->verify across families:
+
+    Attributes:
+        demo: The demonstration this task is compiled from -- a compiled
+            ``bundle_dir`` (:class:`pathlib.Path` / str), a ``Demo`` object,
+            or None. What a policy replays.
+        verifier: A :class:`TaskVerifierRegistry` key (or None). When set and
+            the env carries a registry, :meth:`Environment.verify` dispatches
+            to it; otherwise the env falls back to its native verifier.
+        env: Which environment family scores this task --
+            ``"waa" | "parallels" | "openemr" | "mockmed"`` (and, in phase 2,
+            ``"osworld" | "browsergym"``). Recorded on every metrics row.
+    """
+
+    demo: Any | None = None
+    verifier: str | None = None
+    env: str = ""
+
+    @classmethod
+    def from_benchmark_task(
+        cls,
+        task: BenchmarkTask,
+        *,
+        env: str = "",
+        verifier: str | None = None,
+        demo: Any | None = None,
+    ) -> "MetaTask":
+        """Wrap an existing :class:`BenchmarkTask`, adding the meta fields.
+
+        Copies every canonical field losslessly, so an adapter's own
+        ``load_task`` output can be promoted to a ``MetaTask`` without re-parsing
+        the benchmark's config.
+        """
+        return cls(
+            task_id=task.task_id,
+            instruction=task.instruction,
+            domain=task.domain,
+            initial_state_ref=task.initial_state_ref,
+            time_limit_steps=task.time_limit_steps,
+            raw_config=dict(task.raw_config or {}),
+            evaluation_spec=task.evaluation_spec,
+            demo=demo,
+            verifier=verifier,
+            env=env,
+        )
+
+
+@runtime_checkable
+class Environment(Protocol):
+    """One interface every benchmark family conforms to for the meta-benchmark.
+
+    A structural (``runtime_checkable``) protocol: any object exposing these
+    five methods *is* an ``Environment`` -- the existing adapters conform via
+    the thin shims in :mod:`openadapt_evals.harness.adapters`, no inheritance
+    required. This is the unification point of the audit's "extend
+    openadapt-evals, ~80% reuse" finding.
+
+    The critical unification is :meth:`verify`: a SINGLE entry point that
+    delegates to the environment's *native* verifier (WAA's evaluator, a
+    registry verifier, or a flow ``EffectVerifier``) and always returns a
+    :class:`VerificationResult`. Ground truth for "did the task succeed?" comes
+    from here -- never from a policy's self-report.
+    """
+
+    def reset(self, task: BenchmarkTask) -> Observation:
+        """Reset to ``task``'s initial state and return the first observation."""
+        ...
+
+    def observe(self) -> Observation:
+        """Return the current observation without advancing the environment."""
+        ...
+
+    def act(
+        self, action: BenchmarkAction
+    ) -> "tuple[Observation, bool, dict[str, Any]]":
+        """Execute ``action``; return ``(observation, done, info)``."""
+        ...
+
+    def verify(self, task: BenchmarkTask) -> VerificationResult:
+        """Score ``task`` via the env's native verifier (the unified gate)."""
+        ...
+
+    def close(self) -> None:
+        """Release resources (VMs, browsers, sessions)."""
+        ...
+
+
+@dataclass
+class _NullObservation:
+    """Placeholder kept for callers that need an empty observation sentinel."""
+
+    raw_observation: dict[str, Any] = field(default_factory=dict)

--- a/openadapt_evals/harness/runner.py
+++ b/openadapt_evals/harness/runner.py
@@ -1,0 +1,396 @@
+"""The meta-runner: one driver, one metrics row, across every environment.
+
+:func:`run_meta` drives the demonstration-compiler loop --
+record -> compile -> replay (-> heal) -> **verify** -- against ANY
+:class:`~openadapt_evals.harness.protocol.Environment`, and emits ONE JSONL row
+per ``(env, task, mode)``. The row's ``replay_success`` is the environment's
+OWN verifier verdict (:meth:`Environment.verify`), never the policy's
+self-report -- the meta-benchmark measures real success, not claimed success.
+
+A *policy* is any callable ``(env, task, obs) -> PolicyOutcome`` that drives the
+env forward from the reset observation. Two builders wrap the EXISTING policies:
+
+- :func:`make_replay_policy` -- the demonstrate-then-replay path
+  (:mod:`openadapt_evals.flow.replay_runner`): replays a compiled bundle with
+  ~0 model calls and reports structural-rung usage + heal events.
+- :func:`make_hybrid_policy` -- the compiled-first / agent-fallback-on-halt
+  path (:class:`openadapt_evals.flow.hybrid_agent.HybridFlowAgent`).
+
+Plus :func:`make_agent_policy`, a generic ``BenchmarkAgent`` driver over
+``env.act`` (used for WAA/mock adapter envs and the tests).
+
+This module is stdlib-only at import time; the flow policies import
+``openadapt_flow`` lazily inside their builders.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from openadapt_types import BenchmarkAction, BenchmarkObservation, BenchmarkTask
+
+from openadapt_evals.harness.protocol import Environment, Observation
+
+logger = logging.getLogger(__name__)
+
+#: A policy drives the env forward and reports what it did (NOT whether it
+#: succeeded -- success is the env verifier's job). Signature:
+#: ``(env, task, reset_observation) -> PolicyOutcome``.
+Policy = Callable[[Environment, BenchmarkTask, Observation], "PolicyOutcome"]
+
+
+@dataclass
+class PolicyOutcome:
+    """What a policy reports after driving one task (self-reported, not scored).
+
+    Attributes:
+        reported_success: The policy's OWN belief it finished (diagnostic only;
+            the env verifier is ground truth).
+        model_calls: VLM/LLM calls made (~0 for a healthy compiled replay).
+        structural_rung_counts: Per-rung structural-verification fire counts.
+        num_steps: Steps executed.
+        heal_count: Self-heal events triggered.
+        cost_usd: Model spend in dollars (from the cost layer / step logs).
+        terminal_outcome: ``"success" | "halt" | "error" | ...`` if known.
+        error: Error string if the policy aborted.
+    """
+
+    reported_success: bool = False
+    model_calls: int = 0
+    structural_rung_counts: dict[str, int] = field(default_factory=dict)
+    num_steps: int = 0
+    heal_count: int = 0
+    cost_usd: float = 0.0
+    terminal_outcome: Optional[str] = None
+    error: Optional[str] = None
+
+    @property
+    def structural_rung_fire_total(self) -> int:
+        return sum(self.structural_rung_counts.values())
+
+    @property
+    def structural_rung_rate(self) -> float:
+        return (
+            self.structural_rung_fire_total / self.num_steps if self.num_steps else 0.0
+        )
+
+
+@dataclass
+class MetaMetricsRow:
+    """ONE row per ``(env, task, mode)`` -- the meta-benchmark's unit of output.
+
+    The required schema (identical across WAA, Parallels, MockMed, OpenEMR):
+
+    - ``env`` / ``task_id`` / ``mode``: which family, task, and policy.
+    - ``replay_success``: the env VERIFIER's verdict (ground truth).
+    - ``structural_rung_rate``: structural-verification fires per step.
+    - ``model_calls``: VLM/LLM calls (compiled replay ~0).
+    - ``effect_verdict``: three-valued effect verdict when the env is
+      effect-verified (``confirmed`` / ``refuted`` / ``indeterminate``), else
+      None -- the "silent wrong-action" signal.
+    - ``wall_ms`` / ``cost_usd``: wall-clock and model spend.
+
+    Diagnostic extras (``reported_success``, ``verifier_score``, ``num_steps``,
+    ``heal_count``, ``verifier_source``, ``error``) sit alongside; they never
+    substitute for ``replay_success``.
+    """
+
+    env: str
+    task_id: str
+    mode: str
+    replay_success: bool
+    structural_rung_rate: float
+    model_calls: int
+    effect_verdict: Optional[str]
+    wall_ms: float
+    cost_usd: float
+    # Diagnostics (never override replay_success).
+    reported_success: bool = False
+    verifier_score: float = 0.0
+    verifier_source: Optional[str] = None
+    num_steps: int = 0
+    heal_count: int = 0
+    structural_rung_counts: dict[str, int] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def as_dict(self) -> dict:
+        d = asdict(self)
+        d["structural_rung_rate"] = round(self.structural_rung_rate, 4)
+        d["wall_ms"] = round(self.wall_ms, 2)
+        d["cost_usd"] = round(self.cost_usd, 6)
+        d["verifier_score"] = round(self.verifier_score, 4)
+        return d
+
+
+def run_meta(
+    env: Environment,
+    task: BenchmarkTask,
+    policy: Policy,
+    *,
+    mode: Optional[str] = None,
+    jsonl_path: Optional[Path | str] = None,
+) -> MetaMetricsRow:
+    """Drive record->compile->replay(->heal)->verify for one task; emit a row.
+
+    Args:
+        env: The environment (any :class:`Environment`).
+        task: The task to run (a :class:`~openadapt_evals.harness.protocol.MetaTask`
+            carries ``env`` / ``verifier`` / ``demo``).
+        policy: Callable that drives the env from the reset observation and
+            returns a :class:`PolicyOutcome`.
+        mode: Row label for the policy arm (default: ``getattr(policy, "mode",
+            policy.__name__)`` or ``"policy"``).
+        jsonl_path: When set, the row is appended as one JSON line here.
+
+    Returns:
+        The :class:`MetaMetricsRow`. ``replay_success`` is the env verifier's
+        verdict -- computed here, after the policy runs -- not the policy's
+        self-report.
+    """
+    env_name = getattr(task, "env", "") or getattr(env, "name", "") or "unknown"
+    mode_label = mode or getattr(policy, "mode", None) or getattr(
+        policy, "__name__", "policy"
+    )
+
+    start = time.monotonic()
+    outcome: PolicyOutcome
+    error: Optional[str] = None
+    try:
+        obs = env.reset(task)
+        outcome = policy(env, task, obs)
+        error = outcome.error
+    except Exception as e:  # noqa: BLE001 - one bad task must not abort a suite
+        logger.exception("policy failed for %s", getattr(task, "task_id", "?"))
+        outcome = PolicyOutcome(terminal_outcome="error", error=str(e))
+        error = str(e)
+
+    # Ground truth: the ENV's own verifier, never the policy's self-report.
+    verifier_result = None
+    try:
+        verifier_result = env.verify(task)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("verify() failed for %s: %s", getattr(task, "task_id", "?"), e)
+        error = error or f"verify error: {e}"
+
+    wall_ms = (time.monotonic() - start) * 1000.0
+
+    success = bool(getattr(verifier_result, "success", False))
+    score = float(getattr(verifier_result, "score", 0.0) or 0.0)
+    details = getattr(verifier_result, "details", {}) or {}
+
+    row = MetaMetricsRow(
+        env=env_name,
+        task_id=getattr(task, "task_id", "?"),
+        mode=str(mode_label),
+        replay_success=success,
+        structural_rung_rate=outcome.structural_rung_rate,
+        model_calls=outcome.model_calls,
+        effect_verdict=details.get("effect_verdict"),
+        wall_ms=wall_ms,
+        cost_usd=outcome.cost_usd,
+        reported_success=outcome.reported_success,
+        verifier_score=score,
+        verifier_source=details.get("source"),
+        num_steps=outcome.num_steps,
+        heal_count=outcome.heal_count,
+        structural_rung_counts=dict(outcome.structural_rung_counts),
+        error=error,
+    )
+
+    if jsonl_path is not None:
+        path = Path(jsonl_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row.as_dict()) + "\n")
+
+    return row
+
+
+def run_meta_suite(
+    envs_tasks: "list[tuple[Environment, BenchmarkTask, Policy]]",
+    *,
+    jsonl_path: Optional[Path | str] = None,
+) -> list[MetaMetricsRow]:
+    """Run many ``(env, task, policy)`` triples, emitting one row each."""
+    return [
+        run_meta(env, task, policy, jsonl_path=jsonl_path)
+        for env, task, policy in envs_tasks
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Policies wrapping the EXISTING replay / hybrid / agent drivers.
+# ---------------------------------------------------------------------------
+
+
+def _outcome_from_run_report(report: Any) -> PolicyOutcome:
+    """Map a flow ``RunReport``-like object to a :class:`PolicyOutcome`.
+
+    Same field surface the flow replay_runner / hybrid_agent already read
+    (``rung_counts`` / ``model_calls`` / ``heal_count`` / ``results`` / ...).
+    """
+    rung_counts = dict(getattr(report, "rung_counts", {}) or {})
+    results = getattr(report, "results", []) or []
+    terminal = getattr(report, "terminal_outcome", None)
+    reported = bool(getattr(report, "success", False))
+    return PolicyOutcome(
+        reported_success=reported,
+        model_calls=int(getattr(report, "model_calls", 0) or 0),
+        structural_rung_counts=rung_counts,
+        num_steps=len(results),
+        heal_count=int(getattr(report, "heal_count", 0) or 0),
+        cost_usd=float(getattr(report, "est_model_cost_usd", 0.0) or 0.0),
+        terminal_outcome=terminal,
+    )
+
+
+def make_replay_policy(
+    server_url: str,
+    *,
+    run_root: Path | str = "meta_runs",
+    replay_fn: Optional[Callable] = None,
+) -> Policy:
+    """A policy that replays ``task.demo``'s compiled bundle (the replay leg).
+
+    Wraps :func:`openadapt_evals.flow.replay_runner._default_replay_fn` (a
+    ``WindowsBackend`` replay against the WAA/win_agent ``/screenshot`` +
+    ``/execute_windows`` contract). ``replay_fn`` is injectable for tests -- no
+    flow extra, no VM needed.
+    """
+
+    def _policy(env: Environment, task: BenchmarkTask, obs: Observation) -> PolicyOutcome:
+        bundle_dir = getattr(task, "demo", None)
+        if bundle_dir is None:
+            return PolicyOutcome(
+                terminal_outcome="error",
+                error="replay policy needs task.demo (a compiled bundle_dir)",
+            )
+        fn = replay_fn
+        if fn is None:  # pragma: no cover - lazy real path
+            from openadapt_evals.flow.replay_runner import _default_replay_fn
+
+            fn = _default_replay_fn
+        run_dir = Path(run_root) / getattr(task, "task_id", "task")
+        run_dir.mkdir(parents=True, exist_ok=True)
+        report = fn(Path(bundle_dir), server_url, run_dir, getattr(task, "raw_config", {}))
+        return _outcome_from_run_report(report)
+
+    _policy.mode = "replay"  # type: ignore[attr-defined]
+    return _policy
+
+
+def make_hybrid_policy(base_agent: Any, server_url: str, **hybrid_kwargs: Any) -> Policy:
+    """A policy wrapping :class:`HybridFlowAgent` (compiled-first, agent fallback).
+
+    The hybrid agent replays the compiled bundle and, only on a detected halt
+    (and only if the shared spend ledger allows), hands the live env to
+    ``base_agent``. Metrics are read from the agent's ``metrics`` dict after it
+    declares done.
+    """
+
+    def _policy(env: Environment, task: BenchmarkTask, obs: Observation) -> PolicyOutcome:
+        from openadapt_evals.flow.hybrid_agent import HybridFlowAgent
+
+        bundle_dir = getattr(task, "demo", None)
+        if bundle_dir is None:
+            return PolicyOutcome(
+                terminal_outcome="error",
+                error="hybrid policy needs task.demo (a compiled bundle_dir)",
+            )
+        agent = HybridFlowAgent(
+            base_agent=base_agent,
+            bundle_dir=bundle_dir,
+            server_url=server_url,
+            **hybrid_kwargs,
+        )
+        agent.reset()
+        outcome = _drive_agent_over_env(agent, env, task, obs)
+        m = agent.metrics
+        outcome.model_calls = int(m.get("compiled_model_calls", outcome.model_calls) or 0)
+        outcome.heal_count = int(m.get("compiled_heal_count", outcome.heal_count) or 0)
+        outcome.cost_usd = float(m.get("fallback_cost_usd", outcome.cost_usd) or 0.0)
+        outcome.structural_rung_counts = dict(
+            m.get("compiled_rung_counts", outcome.structural_rung_counts) or {}
+        )
+        outcome.terminal_outcome = m.get("compiled_terminal_outcome", outcome.terminal_outcome)
+        return outcome
+
+    _policy.mode = "hybrid"  # type: ignore[attr-defined]
+    return _policy
+
+
+def make_agent_policy(agent: Any, *, max_steps: int = 15) -> Policy:
+    """A generic policy driving any ``BenchmarkAgent`` over ``env.act``.
+
+    The natural policy for adapter-backed envs (WAA live/mock, Local). Runs the
+    ``act`` -> ``env.act`` loop until the agent (or a step) signals done or
+    ``max_steps`` is hit, accumulating any per-step ``cost_usd`` the agent
+    exposes via ``_last_step_logs``.
+    """
+
+    def _policy(env: Environment, task: BenchmarkTask, obs: Observation) -> PolicyOutcome:
+        agent_reset = getattr(agent, "reset", None)
+        if callable(agent_reset):
+            agent_reset()
+        return _drive_agent_over_env(agent, env, task, obs, max_steps=max_steps)
+
+    _policy.mode = getattr(agent, "mode", "agent")  # type: ignore[attr-defined]
+    return _policy
+
+
+def _drive_agent_over_env(
+    agent: Any,
+    env: Environment,
+    task: BenchmarkTask,
+    obs: Observation,
+    *,
+    max_steps: int = 15,
+) -> PolicyOutcome:
+    """Run the ``agent.act`` <-> ``env.act`` loop; collect a PolicyOutcome."""
+    history: list[tuple[BenchmarkObservation, BenchmarkAction]] = []
+    steps = 0
+    cost = 0.0
+    reported = False
+    terminal: Optional[str] = None
+    for _ in range(max_steps):
+        action = agent.act(obs, task, history)
+        steps += 1
+        logs = getattr(agent, "_last_step_logs", None)
+        if isinstance(logs, dict):
+            cost += float(logs.get("cost_usd", logs.get("cost", 0.0)) or 0.0)
+        next_obs, done, _info = env.act(action)
+        history.append((obs, action))
+        obs = next_obs
+        if action.type == "done":
+            reported = True
+            terminal = "success"
+            break
+        if action.type == "error":
+            terminal = "error"
+            break
+        if done:
+            terminal = terminal or "done"
+            break
+    return PolicyOutcome(
+        reported_success=reported,
+        num_steps=steps,
+        cost_usd=cost,
+        terminal_outcome=terminal,
+    )
+
+
+__all__ = [
+    "Policy",
+    "PolicyOutcome",
+    "MetaMetricsRow",
+    "run_meta",
+    "run_meta_suite",
+    "make_replay_policy",
+    "make_hybrid_policy",
+    "make_agent_policy",
+]

--- a/tests/test_harness_meta_benchmark.py
+++ b/tests/test_harness_meta_benchmark.py
@@ -1,0 +1,325 @@
+"""Targeted, fully-mocked tests for the lightweight meta-benchmark harness.
+
+No flow extra, no VM, no browser, no network, no $ -- every heavy collaborator
+is injected as a fake. Covers:
+
+- the mock WAA adapter (via the shim) and a hand-rolled mock env both satisfy
+  the ``runtime_checkable`` :class:`Environment` protocol;
+- ``run_meta`` on a mock env produces a correct metrics row (ground truth from
+  the env verifier, not the policy self-report);
+- ``verify()`` delegates to the verifier registry AND to a native effect
+  verifier;
+- the Inspect eval-log export round-trips;
+- the OSWorld / BrowserGym stubs raise ``NotImplementedError`` cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from openadapt_types import BenchmarkAction, BenchmarkObservation
+
+from openadapt_evals.adapters.waa.mock import WAAMockAdapter
+from openadapt_evals.evaluation.verifier_registry import (
+    TaskVerifierRegistry,
+    VerificationResult,
+)
+from openadapt_evals.harness import (
+    BenchmarkAdapterEnvironment,
+    BrowserGymAdapter,
+    Environment,
+    MetaMetricsRow,
+    MetaTask,
+    MockMedAdapter,
+    OSWorldAdapter,
+    PolicyOutcome,
+    from_inspect_eval_log,
+    make_agent_policy,
+    run_meta,
+    to_inspect_eval_log,
+    write_inspect_eval_log,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeEnv:
+    """A minimal hand-rolled env that structurally satisfies ``Environment``."""
+
+    name = "mockmed"
+
+    def __init__(self, *, success=True, verdict="confirmed"):
+        self._success = success
+        self._verdict = verdict
+        self.reset_called = False
+
+    def reset(self, task):
+        self.reset_called = True
+        return BenchmarkObservation(raw_observation={"reset": True})
+
+    def observe(self):
+        return BenchmarkObservation(raw_observation={})
+
+    def act(self, action):
+        return BenchmarkObservation(raw_observation={}), action.type == "done", {}
+
+    def verify(self, task):
+        return VerificationResult(
+            success=self._success,
+            score=1.0 if self._success else 0.0,
+            details={"source": "effect_verifier", "effect_verdict": self._verdict},
+        )
+
+    def close(self):
+        pass
+
+
+class _ScriptedAgent:
+    """A BenchmarkAgent-like that types then declares done."""
+
+    mode = "scripted"
+
+    def __init__(self):
+        self._i = 0
+        self._last_step_logs = {"cost_usd": 0.001}
+
+    def reset(self):
+        self._i = 0
+
+    def act(self, obs, task, history=None):
+        self._i += 1
+        if self._i == 1:
+            return BenchmarkAction(type="type", text="hello")
+        return BenchmarkAction(type="done")
+
+
+def _meta_task(**kw):
+    kw.setdefault("task_id", "t1")
+    kw.setdefault("instruction", "do the thing")
+    kw.setdefault("domain", "web")
+    return MetaTask(**kw)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_mock_waa_adapter_shim_conforms_to_environment():
+    env = BenchmarkAdapterEnvironment(WAAMockAdapter(num_tasks=3))
+    assert isinstance(env, Environment)
+
+
+def test_hand_rolled_mock_env_conforms_to_environment():
+    assert isinstance(_FakeEnv(), Environment)
+
+
+def test_incomplete_object_does_not_conform():
+    incomplete = SimpleNamespace(reset=lambda t: None, verify=lambda t: None)
+    assert not isinstance(incomplete, Environment)
+
+
+# ---------------------------------------------------------------------------
+# run_meta produces a correct row
+# ---------------------------------------------------------------------------
+
+
+def test_run_meta_row_uses_env_verifier_not_self_report(tmp_path):
+    # Policy CLAIMS success; env verifier says FAIL -> row must follow the verifier.
+    env = _FakeEnv(success=False, verdict="refuted")
+    task = _meta_task(env="mockmed")
+
+    def lying_policy(env, task, obs):
+        return PolicyOutcome(
+            reported_success=True,
+            model_calls=0,
+            structural_rung_counts={"primary": 4},
+            num_steps=4,
+            cost_usd=0.0,
+        )
+
+    jsonl = tmp_path / "rows.jsonl"
+    row = run_meta(env, task, lying_policy, mode="replay", jsonl_path=jsonl)
+
+    assert isinstance(row, MetaMetricsRow)
+    assert env.reset_called
+    assert row.env == "mockmed"
+    assert row.task_id == "t1"
+    assert row.mode == "replay"
+    assert row.replay_success is False           # ground truth from verify()
+    assert row.reported_success is True          # policy self-report preserved
+    assert row.effect_verdict == "refuted"
+    assert row.structural_rung_rate == 1.0       # 4 fires / 4 steps
+    assert row.model_calls == 0
+    assert row.wall_ms >= 0.0
+    assert row.verifier_source == "effect_verifier"
+
+    # Emitted exactly one JSONL row with the required schema keys.
+    lines = jsonl.read_text().strip().splitlines()
+    assert len(lines) == 1
+    d = json.loads(lines[0])
+    for key in (
+        "env", "task_id", "mode", "replay_success", "structural_rung_rate",
+        "model_calls", "effect_verdict", "wall_ms", "cost_usd",
+    ):
+        assert key in d
+
+
+def test_run_meta_with_agent_policy_over_adapter_env():
+    env = BenchmarkAdapterEnvironment(WAAMockAdapter(num_tasks=1))
+    tasks = env.adapter.list_tasks()
+    task = MetaTask.from_benchmark_task(tasks[0], env="waa")
+    policy = make_agent_policy(_ScriptedAgent(), max_steps=5)
+
+    row = run_meta(env, task, policy)
+    assert row.env == "waa"
+    assert row.mode == "scripted"
+    assert row.num_steps == 2                     # type, then done
+    assert row.reported_success is True
+    assert row.cost_usd == pytest.approx(0.002, abs=1e-6)  # 2 steps * 0.001
+    assert isinstance(row.replay_success, bool)
+
+
+def test_run_meta_survives_policy_exception():
+    env = _FakeEnv(success=True)
+    task = _meta_task(env="mockmed")
+
+    def boom(env, task, obs):
+        raise RuntimeError("policy blew up")
+
+    row = run_meta(env, task, boom, mode="replay")
+    assert "policy blew up" in (row.error or "")
+    # verify() still ran -> ground truth still recorded.
+    assert row.replay_success is True
+
+
+# ---------------------------------------------------------------------------
+# verify() delegation
+# ---------------------------------------------------------------------------
+
+
+def test_verify_delegates_to_registry_when_task_names_a_verifier():
+    reg = TaskVerifierRegistry()
+
+    calls = {}
+
+    @reg.register("my_check")
+    def _v(adapter):
+        calls["adapter"] = adapter
+        return VerificationResult(success=True, score=1.0, details={"k": "v"})
+
+    adapter = WAAMockAdapter(num_tasks=1)
+    env = BenchmarkAdapterEnvironment(adapter, verifier_registry=reg)
+    task = MetaTask.from_benchmark_task(
+        adapter.list_tasks()[0], env="waa", verifier="my_check"
+    )
+
+    result = env.verify(task)
+    assert result.success is True
+    assert result.details["source"] == "verifier_registry"
+    assert result.details["verifier_key"] == "my_check"
+    assert calls["adapter"] is adapter            # registry got the raw adapter
+
+
+def test_verify_falls_back_to_native_evaluate_without_registry_key():
+    adapter = WAAMockAdapter(num_tasks=1)
+    env = BenchmarkAdapterEnvironment(adapter, verifier_registry=TaskVerifierRegistry())
+    task = MetaTask.from_benchmark_task(adapter.list_tasks()[0], env="waa")
+
+    # No actions taken -> mock evaluate() reports failure via adapter.evaluate().
+    result = env.verify(task)
+    assert result.details["source"] == "adapter.evaluate"
+    assert isinstance(result.success, bool)
+
+
+def test_verify_delegates_to_native_effect_verifier():
+    # A fake flow EffectVerifier: verify() ignores args, returns a CONFIRMED-like.
+    fake_verdict = SimpleNamespace(
+        verdict=SimpleNamespace(value="confirmed"),
+        confirmed=True,
+        substrate="rest",
+        reason="record present exactly once",
+        observed_count=1,
+        expected_count=1,
+    )
+    fake_verifier = SimpleNamespace(
+        capture_pre_state=lambda: SimpleNamespace(reachable=True, records=[]),
+        verify=lambda expected, before: fake_verdict,
+    )
+    env = MockMedAdapter(
+        verifier=fake_verifier,
+        backend=SimpleNamespace(screenshot=lambda: b"", viewport=(800, 600)),
+        effect_builder=lambda task: {"kind": "record_written"},
+    )
+    task = _meta_task(env="mockmed", evaluation_spec={"kind": "record_written"})
+    env.reset(task)
+    result = env.verify(task)
+    assert result.success is True
+    assert result.details["effect_verdict"] == "confirmed"
+    assert result.details["substrate"] == "rest"
+
+
+# ---------------------------------------------------------------------------
+# Inspect eval-log round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_eval_log_round_trips(tmp_path):
+    rows = [
+        MetaMetricsRow(
+            env="mockmed", task_id="t1", mode="replay", replay_success=True,
+            structural_rung_rate=1.0, model_calls=0, effect_verdict="confirmed",
+            wall_ms=12.3, cost_usd=0.0,
+        ),
+        MetaMetricsRow(
+            env="openemr", task_id="t2", mode="hybrid", replay_success=False,
+            structural_rung_rate=0.5, model_calls=7, effect_verdict="refuted",
+            wall_ms=45.6, cost_usd=0.03,
+        ),
+    ]
+    doc = to_inspect_eval_log(rows, task_name="meta", model="flow/compiled")
+    assert doc["version"] == 2
+    assert doc["results"]["total_samples"] == 2
+    assert doc["results"]["scores"][0]["metrics"]["accuracy"]["value"] == 0.5
+
+    # Round-trip through JSON text.
+    reloaded = json.loads(json.dumps(doc))
+    back = from_inspect_eval_log(reloaded)
+    assert len(back) == 2
+    assert back[0]["task_id"] == "t1"
+    assert back[0]["replay_success"] is True
+    assert back[0]["effect_verdict"] == "confirmed"
+    assert back[1]["task_id"] == "t2"
+    assert back[1]["replay_success"] is False
+    assert back[1]["model_calls"] == 7
+
+    # write_inspect_eval_log -> file -> read back.
+    path = write_inspect_eval_log(rows, tmp_path / "run.eval.json", task_name="meta")
+    on_disk = json.loads(path.read_text())
+    assert from_inspect_eval_log(on_disk)[0]["env"] == "mockmed"
+
+
+# ---------------------------------------------------------------------------
+# Phase-2 stubs
+# ---------------------------------------------------------------------------
+
+
+def test_external_adapters_raise_not_implemented():
+    with pytest.raises(NotImplementedError):
+        OSWorldAdapter()
+    with pytest.raises(NotImplementedError):
+        BrowserGymAdapter()
+
+
+def test_external_adapters_expose_environment_shaped_methods():
+    # Even unconstructable, the classes advertise the Environment method names so
+    # phase 2 has a concrete surface to fill in.
+    for cls in (OSWorldAdapter, BrowserGymAdapter):
+        for meth in ("reset", "observe", "act", "verify", "close"):
+            assert callable(getattr(cls, meth))


### PR DESCRIPTION
## What

Phase 1 of a **lightweight meta-benchmark**, built by **consolidating the interfaces that already exist in openadapt-evals** — not new infra, not an external harness. Grounded in a code audit + literature review that both concluded "extend openadapt-evals, ~80% reuse."

The repo has three parallel abstractions that each score success a different way:
- `BenchmarkAdapter` (`adapters/base.py`) — `reset`/`step`/`evaluate` (WAA, mock, local)
- `TaskVerifierRegistry` (`evaluation/verifier_registry.py`) — registered verifiers → `VerificationResult`
- the flow-side `EffectVerifier` (openadapt-flow) — CONFIRMED/REFUTED/INDETERMINATE against a real system of record

This PR unifies them behind **one `Environment` protocol** whose `verify()` folds all three scoring paths into a single call, and **one `run_meta()`** that drives record→compile→replay(→heal)→verify and emits **one JSONL row per (env, task, mode)**.

## New package `openadapt_evals/harness/` (lazy PEP-562 imports; no `openadapt_flow` at import time)

- **`protocol.py`** — `runtime_checkable` `Environment` (`reset`/`observe`/`act`/`verify`/`close`) + `MetaTask` (extends `openadapt_types.BenchmarkTask` with `demo`/`verifier`/`env`).
- **`adapters.py`** — `BenchmarkAdapterEnvironment` shim (any `BenchmarkAdapter` → `Environment`, folding `evaluate()` + registry into `verify()`); `MockMedAdapter` (flow `RestRecordVerifier`) + `OpenEMRAdapter` (flow `FhirEffectVerifier`) wrapping the flow Playwright `Backend`. Heavy/live collaborators lazy + injectable/mockable.
- **`runner.py`** — `run_meta(env, task, policy)` → `MetaMetricsRow`: `replay_success` (by the **env's verifier**, not self-report), `structural_rung_rate`, `model_calls`, `effect_verdict`, `wall_ms`, `cost_usd`. Policies wrap the existing replay (`replay_runner`), hybrid (`HybridFlowAgent`), and a generic agent driver.
- **`inspect_export.py`** — portable Inspect eval-log JSON export + round-trip, **without** adopting `inspect_ai` as runtime.
- **`external.py`** — `OSWorldAdapter` + `BrowserGymAdapter` **phase-2 stubs**: `NotImplementedError` + docstrings on how each env's native execution verifier wires into `verify()`. Nothing installed.

## Metrics row schema (per env/task/mode)

`env, task_id, mode, replay_success, structural_rung_rate, model_calls, effect_verdict, wall_ms, cost_usd` (+ diagnostics: `reported_success`, `verifier_score`, `verifier_source`, `num_steps`, `heal_count`, `structural_rung_counts`, `error`).

## Verification (targeted, fully mocked — no live Azure/VM/paid infra)

`tests/test_harness_meta_benchmark.py` — **12 pass**: protocol conformance (`runtime_checkable`), `run_meta` row correctness (ground truth from `verify()`, not the policy's self-report), registry + native effect-verifier delegation, Inspect-log round-trip, clean `NotImplementedError` from the external stubs. Also verified: importing the package does not pull in `openadapt_flow`; ruff clean; related existing suites (`test_verifier_registry`, `test_flow_replay_runner`) still green.

## Not in scope (phase 2)

Real OSWorld/BrowserGym wiring (install + native-verifier delegation), and live runs. **Do not merge** — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKrVJJy5jWVCkXAqgUqtqZ