### PR TITLE
ci: enforce the ruff config this repo already declares

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,17 @@ jobs:
       - name: Check published evidence manifest consistency
         run: python scripts/check_published_evidence_freshness.py --offline
 
+      # This repo declared a ruff config for years with nothing enforcing it,
+      # and drifted to 478 findings against its own declared rule set --
+      # including three undefined names. PR #275 cleared all of them; without a
+      # gate the same decay restarts immediately, and the next person to add one
+      # hits the same wall. Costs about 10 seconds inside a job that already
+      # installs ruff, so it needs no runner, no install step and no new
+      # workflow. The linter is version-bounded (ruff>=0.16,<0.17) and the rule
+      # set is explicit, so this cannot go red because ruff shipped a release.
+      - name: Lint
+        run: uv run --no-sources ruff check .
+
       - name: Run tests
         run: |
           uv run --no-sources pytest tests/ -q \


### PR DESCRIPTION
`[tool.ruff]` has existed here for a long time with nothing running it. By the
time PR #275 looked, the tree had drifted to 478 findings against its own
declared rule set -- among them three undefined names that no reviewer would
have let through if anything had been checking. #275 cleared all of them and
made the config honest; this makes it stay honest.

The step goes in the existing `test` job, which already runs `uv sync --locked
--extra dev` and therefore already has ruff installed. It adds no runner, no
install step and no workflow: `ruff check .` takes about 40 ms on this tree, so
the marginal cost is the step overhead, roughly 10 seconds.

It cannot go red because ruff shipped a release. `#275` bounded the linter to
`ruff>=0.16,<0.17` and pinned it in `uv.lock`, and the rule set is stated
explicitly as `select = ["E","F","I","W"]`. Both have to be changed by a person
before the answer can move -- which is the whole point of this change and #275.

Verified against this exact tree with the locked ruff 0.16.0: `All checks
passed!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM