### PR TITLE
fix(evals): make "could not measure" representable everywhere it produced a number

### DIFF
--- a/openadapt_evals/adapters/__init__.py
+++ b/openadapt_evals/adapters/__init__.py
@@ -39,6 +39,7 @@ from openadapt_evals.adapters.base import (
     BenchmarkObservation,
     BenchmarkResult,
     BenchmarkTask,
+    EvaluationUnavailableError,
     StaticDatasetAdapter,
     UIElement,
 )
@@ -72,6 +73,7 @@ __all__ = [
     "BenchmarkObservation",
     "BenchmarkAction",
     "BenchmarkResult",
+    "EvaluationUnavailableError",
     "StaticDatasetAdapter",
     "UIElement",
     # Local adapter

--- a/openadapt_evals/adapters/base.py
+++ b/openadapt_evals/adapters/base.py
@@ -31,6 +31,21 @@ if TYPE_CHECKING:
     pass
 
 
+class EvaluationUnavailableError(RuntimeError):
+    """A task could not be scored, as distinct from having scored badly.
+
+    Adapters signal this condition on a :class:`BenchmarkResult` via
+    ``error_type in {"infrastructure", "evaluation"}``. Any API that flattens a
+    result down to a bare float must raise this instead of returning ``0.0``:
+    an unreachable VM reported as a legitimate 0% is the single worst defect an
+    evaluation harness can have, because the number looks measured.
+    """
+
+    def __init__(self, message: str, error_type: str = "infrastructure") -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
 @dataclass
 class BenchmarkResult:
     """Result of a single task evaluation.

--- a/openadapt_evals/adapters/rl_env.py
+++ b/openadapt_evals/adapters/rl_env.py
@@ -64,7 +64,9 @@ from openadapt_evals.adapters.base import (
     BenchmarkAction,
     BenchmarkAdapter,
     BenchmarkObservation,
+    BenchmarkResult,
     BenchmarkTask,
+    EvaluationUnavailableError,
 )
 
 # Avoid circular import — TaskConfig imported lazily.
@@ -302,8 +304,16 @@ class RLEnvironment:
         if self._evaluate_every_step and self._current_task is not None:
             try:
                 result = self._adapter.evaluate(self._current_task)
-                info["evaluation_score"] = result.score
-                info["evaluation_success"] = result.success
+                if result.error_type:
+                    # Not scored. Recording a 0.0 here would look identical to
+                    # a step the agent genuinely failed.
+                    info["evaluation_error"] = (
+                        f"{result.error_type}: {result.reason or result.error}"
+                    )
+                    info["evaluation_error_type"] = result.error_type
+                else:
+                    info["evaluation_score"] = result.score
+                    info["evaluation_success"] = result.success
             except Exception as e:
                 logger.warning("Per-step evaluation failed at step %d: %s", self._step_count, e)
                 info["evaluation_error"] = str(e)
@@ -460,15 +470,15 @@ class RLEnvironment:
             raise RuntimeError("No screenshot available from adapter")
         return Image.open(io.BytesIO(obs.screenshot))
 
-    def evaluate(self) -> float:
-        """Run the WAA evaluator on the current VM state.
+    def evaluate_result(self) -> BenchmarkResult:
+        """Run the adapter's evaluator and return the full result.
 
-        Returns the task-success score (0.0-1.0). For binary tasks, this is
-        0.0 (failure) or 1.0 (success). Suitable as the terminal reward for
-        GRPO or other RL algorithms.
+        Unlike :meth:`evaluate`, this preserves ``error_type``, so a caller can
+        tell an unreachable VM (``error_type == "infrastructure"``) from a task
+        the agent genuinely failed (``error_type is None, score == 0.0``).
 
         Returns:
-            Score between 0.0 and 1.0.
+            The adapter's :class:`BenchmarkResult`, unmodified.
 
         Raises:
             RuntimeError: If no task has been loaded (call reset() first).
@@ -478,16 +488,51 @@ class RLEnvironment:
 
         result = self._adapter.evaluate(self._current_task)
 
-        # Backfill reward on the last trajectory step
-        if self._trajectory:
+        # Backfill reward on the last trajectory step only when the score is a
+        # real measurement; an infrastructure 0.0 is not a reward signal.
+        if self._trajectory and not result.error_type:
             self._trajectory[-1].reward = result.score
 
         logger.info(
-            "Evaluation: task=%s, success=%s, score=%.2f",
+            "Evaluation: task=%s, success=%s, score=%.2f, error_type=%s",
             self._current_task.task_id,
             result.success,
             result.score,
+            result.error_type,
         )
+        return result
+
+    def evaluate(self) -> float:
+        """Run the WAA evaluator on the current VM state.
+
+        Returns the task-success score (0.0-1.0). For binary tasks, this is
+        0.0 (failure) or 1.0 (success). Suitable as the terminal reward for
+        GRPO or other RL algorithms.
+
+        The adapters go to real trouble to mark infrastructure failures
+        (``BenchmarkResult.error_type``); flattening the result to a bare float
+        used to throw that away, so 40 tasks whose VM stopped answering were
+        published as 40 genuine agent failures. This method now raises rather
+        than returning an unmeasured 0.0. Callers that want the tri-state
+        should use :meth:`evaluate_result`.
+
+        Returns:
+            Score between 0.0 and 1.0.
+
+        Raises:
+            RuntimeError: If no task has been loaded (call reset() first).
+            EvaluationUnavailableError: If the task could not be scored
+                because of an infrastructure or evaluator failure.
+        """
+        result = self.evaluate_result()
+
+        if result.error_type in ("infrastructure", "evaluation"):
+            raise EvaluationUnavailableError(
+                f"task {result.task_id} was not scored "
+                f"({result.error_type}): {result.reason or result.error}",
+                error_type=result.error_type,
+            )
+
         return result.score
 
     def check_milestones_incremental(
@@ -613,13 +658,23 @@ class RLEnvironment:
                 # - Benchmarking: 180s timeout, 3 retries (thorough)
                 # - Training: 15s timeout, 1 retry (fast feedback)
                 # The TRL wrapper sets training-appropriate timeouts.
+                binary_score = 0.0
+                binary_unavailable: Exception | None = None
                 try:
                     binary_score = self.evaluate()
-                except Exception:
-                    binary_score = 0.0
+                except Exception as exc:
+                    # Record WHY rather than folding it into a 0.0. A binary
+                    # evaluator that could not run is not the same as one that
+                    # ran and said "no", and `max(milestone, 0.0)` silently
+                    # publishes the milestone high-water mark as a task score.
+                    binary_unavailable = exc
+                    logger.warning(
+                        "evaluate_dense: binary evaluation did not run: %s", exc,
+                    )
 
                 # If binary eval returned 0.0 (endpoint down or task
                 # failed), try local evaluation via task config checks.
+                local_check_ran = False
                 if (
                     binary_score == 0.0
                     and self._task_config.checks
@@ -635,6 +690,7 @@ class RLEnvironment:
                                 screenshot, server_url,
                             )
                         )
+                        local_check_ran = True
                         if binary_score > 0:
                             logger.info(
                                 "evaluate_dense: local check fallback "
@@ -645,6 +701,23 @@ class RLEnvironment:
                             "evaluate_dense: local check fallback "
                             "failed: %s", exc,
                         )
+
+                if binary_unavailable is not None and not local_check_ran:
+                    # Nothing scored this task: the binary evaluator could not
+                    # run and no local check stood in for it. The milestone
+                    # high-water mark is a progress signal, not a task score,
+                    # so returning it here would publish a number that was
+                    # never measured.
+                    raise EvaluationUnavailableError(
+                        f"task {self._current_task.task_id} was not scored: "
+                        f"binary evaluation did not run "
+                        f"({binary_unavailable}) and no local check fallback "
+                        f"was available; the milestone high-water mark "
+                        f"({milestone_score:.2f}) is not a task score",
+                        error_type=getattr(
+                            binary_unavailable, "error_type", "infrastructure",
+                        ),
+                    ) from binary_unavailable
 
                 # Use the higher of milestone score and binary score
                 score = max(milestone_score, binary_score)

--- a/openadapt_evals/adapters/waa/live.py
+++ b/openadapt_evals/adapters/waa/live.py
@@ -1064,13 +1064,7 @@ class WAALiveAdapter(BenchmarkAdapter):
 
             if resp.status_code == 200:
                 result = resp.json()
-                return BenchmarkResult(
-                    task_id=task.task_id,
-                    success=result.get("success", False),
-                    score=result.get("score", 0.0),
-                    num_steps=self._step_count,
-                    reason=result.get("reason"),
-                )
+                return self._result_from_evaluate_response(task, result)
 
             elif resp.status_code == 404 or (
                 resp.status_code == 500 and "404 Not Found" in resp.text
@@ -1092,12 +1086,8 @@ class WAALiveAdapter(BenchmarkAdapter):
                             # Cache the working URL for future calls
                             self.config.evaluate_url = fallback_url
                             result = resp2.json()
-                            return BenchmarkResult(
-                                task_id=task.task_id,
-                                success=result.get("success", False),
-                                score=result.get("score", 0.0),
-                                num_steps=self._step_count,
-                                reason=result.get("reason"),
+                            return self._result_from_evaluate_response(
+                                task, result,
                             )
                     except Exception as exc:
                         logger.warning("Fallback evaluate at %s failed: %s", fallback_url, exc)
@@ -1106,7 +1096,12 @@ class WAALiveAdapter(BenchmarkAdapter):
                     f"/evaluate endpoint not found at {evaluate_endpoint}. "
                     "Ensure the evaluate server is running on port 5050."
                 )
-                return self._evaluate_fallback(task)
+                # The evaluate server is not deployed. That is an
+                # infrastructure fact about our harness, not a verdict on the
+                # agent, and it must not be aggregated as a scored 0.0.
+                result = self._evaluate_fallback(task)
+                result.error_type = "infrastructure"
+                return result
 
             else:
                 logger.error(
@@ -1118,6 +1113,9 @@ class WAALiveAdapter(BenchmarkAdapter):
                     score=0.0,
                     num_steps=self._step_count,
                     reason=f"Evaluation failed: HTTP {resp.status_code}",
+                    # The evaluate server erroring is our infrastructure
+                    # failing, not the agent failing the task.
+                    error_type="infrastructure",
                 )
 
         except requests.Timeout:
@@ -1142,6 +1140,30 @@ class WAALiveAdapter(BenchmarkAdapter):
             result = self._evaluate_fallback(task)
             result.error_type = "infrastructure"
             return result
+
+    def _result_from_evaluate_response(
+        self, task: BenchmarkTask, result: dict,
+    ) -> BenchmarkResult:
+        """Build a BenchmarkResult from an /evaluate 200 body.
+
+        The evaluate server distinguishes "measured" from "could not measure"
+        via ``scored``/``error_type``; a 200 carrying ``scored: false`` is an
+        unscored task, and copying only ``success``/``score`` out of it is how
+        an unreachable VM becomes a legitimate 0% row. Bodies from older
+        servers have neither field and are treated as measurements, which is
+        what they were.
+        """
+        error_type = result.get("error_type")
+        if result.get("scored") is False and not error_type:
+            error_type = "evaluation"
+        return BenchmarkResult(
+            task_id=task.task_id,
+            success=result.get("success", False),
+            score=result.get("score", 0.0),
+            num_steps=self._step_count,
+            reason=result.get("reason"),
+            error_type=error_type,
+        )
 
     def _evaluate_fallback(self, task: BenchmarkTask) -> BenchmarkResult:
         """Fallback when proper evaluation unavailable - returns failure.

--- a/openadapt_evals/agents/http_agent.py
+++ b/openadapt_evals/agents/http_agent.py
@@ -108,29 +108,46 @@ class HttpAgent(BenchmarkAgent):
             )
             resp.raise_for_status()
             data = resp.json()
+        # `done` means "the agent finished the task" and the eval loop breaks
+        # cleanly with no error marker; a sidecar that OOMed at step 0 would be
+        # scored as an agent that ran and failed. `error` with an explicit
+        # error_type is the shape the harness already knows how to exclude
+        # (see claude_computer_use_agent).
         except requests.ConnectionError as e:
             logger.error("Connection failed: %s", e)
             return BenchmarkAction(
-                type="done",
-                raw_action={"error": f"connection_failed: {e}"},
+                type="error",
+                raw_action={
+                    "error": f"connection_failed: {e}",
+                    "error_type": "infrastructure",
+                },
             )
         except requests.Timeout as e:
             logger.error("Request timed out: %s", e)
             return BenchmarkAction(
-                type="done",
-                raw_action={"error": f"timeout: {e}"},
+                type="error",
+                raw_action={
+                    "error": f"timeout: {e}",
+                    "error_type": "infrastructure",
+                },
             )
         except requests.HTTPError as e:
             logger.error("HTTP error: %s", e)
             return BenchmarkAction(
-                type="done",
-                raw_action={"error": f"http_error: {e}"},
+                type="error",
+                raw_action={
+                    "error": f"http_error: {e}",
+                    "error_type": "infrastructure",
+                },
             )
         except (ValueError, KeyError) as e:
             logger.error("Invalid response: %s", e)
             return BenchmarkAction(
-                type="done",
-                raw_action={"error": f"invalid_response: {e}"},
+                type="error",
+                raw_action={
+                    "error": f"invalid_response: {e}",
+                    "error_type": "infrastructure",
+                },
             )
 
         return _parse_action_response(data)
@@ -177,7 +194,17 @@ def _parse_action_response(data: dict[str, Any]) -> BenchmarkAction:
     Returns:
         Parsed BenchmarkAction.
     """
-    action_type = data.get("type", "done")
+    # No default: a body with no `type` is a malformed response, and
+    # defaulting it to "done" reads as a clean agent finish.
+    action_type = data.get("type")
+    if not action_type:
+        return BenchmarkAction(
+            type="error",
+            raw_action={
+                "error": f"response has no 'type' field: {data!r}"[:500],
+                "error_type": "agent",
+            },
+        )
 
     return BenchmarkAction(
         type=action_type,

--- a/openadapt_evals/benchmarks/azure.py
+++ b/openadapt_evals/benchmarks/azure.py
@@ -69,6 +69,11 @@ VM_TIER_COSTS = {
     "complex": 0.384,  # $0.384/hour
 }
 
+# How many consecutive poll failures for one worker before the run is failed
+# rather than polled forever. A worker we cannot reach has produced NO results,
+# which is not the same as having produced zero-score ones.
+_MAX_WORKER_POLL_ERRORS = 10
+
 # Spot instance hourly costs (approximately 70-80% discount)
 VM_TIER_SPOT_COSTS = {
     "simple": 0.024,   # ~$0.024/hour (75% discount)
@@ -1179,6 +1184,7 @@ class AzureWAAOrchestrator:
     ) -> list[BenchmarkResult]:
         """Wait for all workers and collect results."""
         all_results: list[BenchmarkResult] = []
+        consecutive_errors: dict[int, int] = {}
 
         # Poll workers for completion
         pending_workers = [w for w in workers if w.status == "running"]
@@ -1207,8 +1213,34 @@ class AzureWAAOrchestrator:
                             f"{len(results)} results"
                         )
 
+                except NotImplementedError:
+                    # Never swallow a stub: it would poll forever, and the
+                    # alternative (returning what it has) is a partial result
+                    # set reported as a complete run.
+                    raise
+
                 except Exception as e:
                     logger.warning(f"Error checking worker {worker.worker_id}: {e}")
+                    consecutive_errors[worker.worker_id] = (
+                        consecutive_errors.get(worker.worker_id, 0) + 1
+                    )
+                    if consecutive_errors[worker.worker_id] >= _MAX_WORKER_POLL_ERRORS:
+                        # A worker we can no longer reach has NOT produced zero
+                        # results; it has produced none. Fail the run instead of
+                        # polling it forever or dropping it silently from the
+                        # denominator.
+                        worker.status = "failed"
+                        worker.error = str(e)
+                        pending_workers.remove(worker)
+                        raise RuntimeError(
+                            f"Worker {worker.worker_id} "
+                            f"({worker.compute_name}) could not be polled "
+                            f"{_MAX_WORKER_POLL_ERRORS} times in a row; its "
+                            f"{len(worker.assigned_tasks)} tasks were not "
+                            f"scored. Last error: {e}"
+                        ) from e
+                else:
+                    consecutive_errors[worker.worker_id] = 0
 
             if pending_workers:
                 time.sleep(30)
@@ -1216,20 +1248,26 @@ class AzureWAAOrchestrator:
         return all_results
 
     def _fetch_worker_results(self, worker: WorkerState) -> list[BenchmarkResult]:
-        """Fetch results from a worker's output storage."""
-        # In a real implementation, this would download results from blob storage
-        # For now, return placeholder results
-        results = []
-        for task_id in worker.assigned_tasks:
-            results.append(
-                BenchmarkResult(
-                    task_id=task_id,
-                    success=False,  # Placeholder
-                    score=0.0,
-                    num_steps=0,
-                )
-            )
-        return results
+        """Fetch results from a worker's output storage.
+
+        Not implemented. This used to synthesize one
+        ``BenchmarkResult(success=False, score=0.0)`` per assigned task, with
+        no ``error``/``error_type``/``reason``, which meant a distributed run
+        that never touched a VM produced a complete, legitimate-looking
+        ``Success rate: 0.0%`` that ``compute_metrics`` could not even filter
+        out as infrastructure. A stub must refuse to produce numbers -- see
+        ``harness/external.py``, which raises for exactly this reason.
+
+        Raises:
+            NotImplementedError: Always, until blob-storage retrieval lands.
+        """
+        raise NotImplementedError(
+            "AzureWAAOrchestrator cannot retrieve worker results yet: "
+            "downloading them from blob storage is unimplemented. Refusing to "
+            f"fabricate {len(worker.assigned_tasks)} zero-score results for "
+            f"worker {worker.worker_id}, which would be published as a real "
+            "0% benchmark run."
+        )
 
     def _cleanup_workers(self, workers: list[WorkerState]) -> None:
         """Delete all worker VMs."""

--- a/openadapt_evals/benchmarks/health_checker.py
+++ b/openadapt_evals/benchmarks/health_checker.py
@@ -38,18 +38,37 @@ class JobStuckError(Exception):
     pass
 
 
+class JobLogsUnavailableError(Exception):
+    """Raised when job logs could not be retrieved.
+
+    Every health verdict in this module is derived from log content. An empty
+    log string used to stand in for "could not fetch", which made
+    ``_has_container_started`` and ``_has_recent_log_activity`` return False
+    unconditionally -- so a perfectly healthy job was reported stuck and, with
+    ``auto_cancel=True``, cancelled. "Could not look" must not be spelled the
+    same way as "looked and saw nothing".
+    """
+    pass
+
+
 @dataclass
 class HealthCheckResult:
     """Result of a health check operation.
 
     Attributes:
-        healthy: Whether the check passed.
+        healthy: Tri-state. True/False are verdicts; ``None`` means the check
+            could not be performed, which is NOT an unhealthy verdict.
         message: Human-readable status message.
         details: Additional diagnostic information.
     """
-    healthy: bool
+    healthy: bool | None
     message: str
     details: dict | None = None
+
+    @property
+    def known(self) -> bool:
+        """True when this result is an actual verdict."""
+        return self.healthy is not None
 
 
 class ContainerHealthChecker:
@@ -106,6 +125,9 @@ class ContainerHealthChecker:
 
         Raises:
             ContainerSetupError: If container startup explicitly failed.
+            JobLogsUnavailableError: If the logs could never be read, so no
+                conclusion about startup is possible. This is distinct from
+                returning False, which asserts the container did not start.
         """
         start_time = time.time()
         logger.info(
@@ -114,6 +136,7 @@ class ContainerHealthChecker:
         )
 
         last_log_content = ""
+        logs_unavailable: str | None = None
 
         while time.time() - start_time < timeout_seconds:
             try:
@@ -140,6 +163,12 @@ class ContainerHealthChecker:
                             f"Container startup failed for {job_name}: {error_msg}"
                         )
 
+            except JobLogsUnavailableError as e:
+                # We never got to look. Timing out on that and reporting
+                # "container did not start" cancels healthy jobs.
+                logs_unavailable = str(e)
+                logger.warning(f"Container status unknown for {job_name}: {e}")
+
             except Exception as e:
                 if isinstance(e, ContainerSetupError):
                     raise
@@ -147,8 +176,16 @@ class ContainerHealthChecker:
 
             time.sleep(poll_interval)
 
-        # Timeout exceeded
         elapsed = time.time() - start_time
+
+        if logs_unavailable is not None:
+            raise JobLogsUnavailableError(
+                f"could not determine whether the container for {job_name} "
+                f"started: logs were unavailable for the whole "
+                f"{elapsed:.1f}s wait ({logs_unavailable})"
+            )
+
+        # Timeout exceeded
         logger.warning(
             f"Container startup timeout for {job_name} "
             f"(elapsed: {elapsed:.1f}s, no startup logs detected)"
@@ -169,7 +206,16 @@ class ContainerHealthChecker:
 
             if job.status == "Running":
                 # Get recent logs to verify activity
-                logs = self._get_job_logs(job_name, last_n_lines=50)
+                try:
+                    logs = self._get_job_logs(job_name, last_n_lines=50)
+                except JobLogsUnavailableError as e:
+                    return HealthCheckResult(
+                        healthy=None,
+                        message=(
+                            f"Job {job_name} health is UNKNOWN: {e}"
+                        ),
+                        details={"status": job.status, "error": str(e)},
+                    )
 
                 if self._has_container_started(logs):
                     return HealthCheckResult(
@@ -235,7 +281,14 @@ class ContainerHealthChecker:
                 )
 
             # Get recent logs
-            logs = self._get_job_logs(job_name)
+            try:
+                logs = self._get_job_logs(job_name)
+            except JobLogsUnavailableError as e:
+                return HealthCheckResult(
+                    healthy=None,
+                    message=f"Job {job_name} progress is UNKNOWN: {e}",
+                    details={"status": job.status, "error": str(e)},
+                )
 
             # Check for recent activity by looking at timestamps in logs
             # If we can't find recent activity, the job may be stuck
@@ -277,23 +330,29 @@ class ContainerHealthChecker:
 
         Returns:
             Log content as string.
+
+        Raises:
+            JobLogsUnavailableError: Always, until real log retrieval lands, or
+                when Azure ML cannot be reached. Never returns "" for either
+                case -- an empty string is a valid log body and would be read
+                as "no container activity".
         """
         try:
-            # Use Azure ML SDK to get logs
-            # Note: This is a simplified implementation
-            # Real implementation would use ml_client.jobs.get_logs() or similar
-            # Result deliberately discarded: this call only confirms the job
-            # exists (it raises otherwise). Real log fetching is the TODO below.
+            # This call only confirms the job exists (it raises otherwise).
             self.ml_client.client.jobs.get(job_name)
-
-            # For now, return empty string as placeholder
-            # In production, this would fetch actual logs
-            # TODO: Implement proper log fetching via Azure ML SDK
-            return ""
-
         except Exception as e:
             logger.warning(f"Failed to fetch logs for {job_name}: {e}")
-            return ""
+            raise JobLogsUnavailableError(
+                f"could not reach Azure ML to fetch logs for {job_name}: {e}"
+            ) from e
+
+        # TODO: Implement proper log fetching via Azure ML SDK
+        # (ml_client.jobs.stream / download job artifacts).
+        raise JobLogsUnavailableError(
+            f"log retrieval for {job_name} is not implemented; every health "
+            "verdict derived from an empty placeholder log was a false "
+            "negative that could cancel a healthy job"
+        )
 
     def _has_container_started(self, logs: str) -> bool:
         """Check if logs indicate successful container startup."""
@@ -376,7 +435,9 @@ class StuckJobDetector:
             auto_cancel: If True, automatically cancel stuck jobs.
 
         Returns:
-            Tuple of (is_stuck, message).
+            Tuple of (is_stuck, message). ``is_stuck`` is False when the check
+            could not be performed -- an unknown verdict is never grounds for
+            cancelling a job.
         """
         # Check for progress
         result = self.container_checker.monitor_job_progress(
@@ -386,6 +447,14 @@ class StuckJobDetector:
 
         if result.healthy:
             return False, result.message
+
+        if result.healthy is None:
+            # We could not tell. Cancelling on "unknown" is how this detector
+            # used to kill every healthy job it looked at.
+            return False, (
+                f"Job {job_name} was NOT checked for progress "
+                f"(not cancelling): {result.message}"
+            )
 
         # Job is stuck
         message = f"Job {job_name} is stuck: {result.message}"

--- a/openadapt_evals/benchmarks/vm_cli.py
+++ b/openadapt_evals/benchmarks/vm_cli.py
@@ -7769,6 +7769,13 @@ def cmd_resources(args):
         for warning in status["warnings"]:
             print(f"  - {warning}")
         print()
+    elif status.get("query_failures"):
+        # "Could not ask Azure" must never print as "nothing is running".
+        print("RESOURCE STATE UNKNOWN: one or more Azure queries did not run.")
+        print("Resources may still be billing.")
+        for failure in status["query_failures"]:
+            print(f"  - {failure}")
+        print()
     else:
         print("No running resources detected.")
         print()

--- a/openadapt_evals/evaluation/__init__.py
+++ b/openadapt_evals/evaluation/__init__.py
@@ -30,7 +30,12 @@ Example usage:
     result = registry.verify("my_task", adapter)
 """
 
-from .client import EvaluationResult, EvaluatorClient
+from .client import (
+    EvaluationError,
+    EvaluationResult,
+    EvaluatorClient,
+    EvaluatorsUnavailableError,
+)
 from .discovery import DiscoveryMethod, VMIPDiscovery, discover_vm_ip
 from .verifier_registry import (
     TaskVerifierRegistry,
@@ -45,6 +50,8 @@ __all__ = [
     "discover_vm_ip",
     "EvaluatorClient",
     "EvaluationResult",
+    "EvaluationError",
+    "EvaluatorsUnavailableError",
     "TaskVerifierRegistry",
     "VerificationResult",
     "register",

--- a/openadapt_evals/evaluation/client.py
+++ b/openadapt_evals/evaluation/client.py
@@ -5,28 +5,75 @@ This approach follows WAA's own design pattern and eliminates the need for a sid
 
 Fallback metrics are provided by ``evaluation.metrics`` (shared with
 ``server/evaluate_endpoint.py``).
+
+**Why this module refuses to degrade silently.** Every value produced here ends
+up as a published benchmark number. A broken WAA evaluators install, an
+unreachable VM, and a task the agent genuinely failed all used to collapse into
+the same ``score=0.0, success=False`` shape, so a caller could not tell a
+measured failure from an unmeasured one. Two things now keep the distinction
+representable:
+
+* ``EvaluatorClient(require_waa_evaluators=True)`` (the default) raises
+  :class:`EvaluatorsUnavailableError` at construction rather than quietly
+  substituting the built-in fallback evaluator for the rest of the run.
+* Every :class:`EvaluationResult` carries ``error_type`` and
+  ``evaluator_source``. ``result.scored`` is ``False`` whenever the number in
+  ``score`` was not produced by a working evaluator, and aggregators must
+  exclude those rows rather than count them as zeros.
 """
 
 import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
 
 logger = logging.getLogger(__name__)
 
 
+class EvaluatorsUnavailableError(RuntimeError):
+    """The WAA evaluators package could not be loaded.
+
+    Raised instead of silently falling back to the built-in evaluator, because
+    a fallback-scored run and a WAA-scored run are not comparable and used to
+    be indistinguishable.
+    """
+
+
+class EvaluationError(RuntimeError):
+    """An evaluation could not be carried out (as opposed to failing)."""
+
+
 @dataclass
 class EvaluationResult:
-    """Result of evaluating a benchmark task."""
+    """Result of evaluating a benchmark task.
+
+    ``error_type`` is the tri-state that separates "measured" from "could not
+    measure":
+
+    * ``None`` -- ``score``/``success`` are a real measurement.
+    * ``"infrastructure"`` -- the VM or server could not be reached; ``score``
+      is not a measurement and must not be aggregated.
+    * ``"evaluation"`` -- the VM answered but the evaluator itself could not
+      run (missing getter, metric raised, unknown metric name); ``score`` is
+      likewise not a measurement.
+    """
+
     success: bool
     score: float
     actual: Any = None
     expected: Any = None
     reason: str = ""
     metrics: Dict[str, Any] = field(default_factory=dict)
+    error_type: Optional[str] = None
+    evaluator_source: str = "waa"
+
+    @property
+    def scored(self) -> bool:
+        """True only when ``score`` is a real measurement."""
+        return self.error_type is None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
@@ -37,6 +84,9 @@ class EvaluationResult:
             "expected": str(self.expected)[:500] if self.expected else None,
             "reason": self.reason,
             "metrics": self.metrics,
+            "error_type": self.error_type,
+            "evaluator_source": self.evaluator_source,
+            "scored": self.scored,
         }
 
 
@@ -58,6 +108,7 @@ class EvaluatorClient:
         port: int = 5000,
         waa_evaluators_path: Optional[Path] = None,
         timeout: int = 30,
+        require_waa_evaluators: bool = True,
     ):
         """Initialize the evaluator client.
 
@@ -66,6 +117,18 @@ class EvaluatorClient:
             port: WAA server port (default 5000).
             waa_evaluators_path: Path to WAA evaluators. If None, searches common locations.
             timeout: HTTP request timeout in seconds.
+            require_waa_evaluators: When True (the default), a missing or
+                broken WAA evaluators package raises
+                :class:`EvaluatorsUnavailableError` instead of degrading to the
+                built-in fallback evaluator. Pass False only when the built-in
+                evaluator is genuinely what you want; results are then stamped
+                ``evaluator_source="fallback"`` so the choice stays visible in
+                every downstream record.
+
+        Raises:
+            ValueError: If the VM IP cannot be determined.
+            EvaluatorsUnavailableError: If ``require_waa_evaluators`` is True
+                and the WAA evaluators package is missing or unimportable.
         """
         from .discovery import discover_vm_ip
 
@@ -81,10 +144,40 @@ class EvaluatorClient:
         self.base_url = f"http://{self.vm_ip}:{self.port}"
 
         # Find and load WAA evaluators
+        self._searched_paths: List[Path] = []
         self._evaluators_path = waa_evaluators_path or self._find_evaluators_path()
         self._getters = None
         self._metrics = None
+        self._evaluators_error: Optional[str] = None
         self._load_evaluators()
+
+        if self._evaluators_error is not None:
+            if require_waa_evaluators:
+                raise EvaluatorsUnavailableError(
+                    f"{self._evaluators_error} Every task this client evaluated "
+                    "would be scored by the built-in fallback evaluator instead "
+                    "of WAA's, and the resulting numbers are not comparable with "
+                    "WAA-scored runs. Install the WAA evaluators, pass "
+                    "waa_evaluators_path explicitly, or construct the client "
+                    "with require_waa_evaluators=False to accept fallback "
+                    "scoring deliberately."
+                )
+            logger.warning(
+                "%s Continuing with the built-in fallback evaluator because "
+                "require_waa_evaluators=False; results are stamped "
+                "evaluator_source='fallback'.",
+                self._evaluators_error,
+            )
+
+    @property
+    def evaluator_source(self) -> str:
+        """``"waa"`` when WAA's own evaluators are loaded, else ``"fallback"``."""
+        return "waa" if self._getters is not None else "fallback"
+
+    @property
+    def evaluators_error(self) -> Optional[str]:
+        """Why the WAA evaluators are unavailable, or None if they loaded."""
+        return self._evaluators_error
 
     def _find_evaluators_path(self) -> Optional[Path]:
         """Find WAA evaluators in common locations."""
@@ -97,6 +190,7 @@ class EvaluatorClient:
             Path.home() / "WindowsAgentArena" / "src" / "win-arena-container" / "client" / "desktop_env",
             Path("/opt/waa/client/desktop_env"),
         ]
+        self._searched_paths = list(search_paths)
 
         for path in search_paths:
             evaluators_dir = path / "evaluators"
@@ -106,8 +200,29 @@ class EvaluatorClient:
         return None
 
     def _load_evaluators(self) -> None:
-        """Load WAA evaluator modules."""
+        """Load WAA evaluator modules, recording why if they cannot be loaded.
+
+        Sets ``self._evaluators_error`` to a non-None string on failure. The two
+        failure modes are kept distinct in the message: nothing was found at any
+        candidate path (a legitimately absent optional install) versus something
+        was found but would not import (a broken install). Both used to leave
+        ``_getters``/``_metrics`` as None with no record, which is what made a
+        broken install indistinguishable from a healthy one.
+        """
         if not self._evaluators_path:
+            searched = ", ".join(str(p) for p in self._searched_paths) or "<none>"
+            self._evaluators_error = (
+                f"WAA evaluators package not found; searched: {searched}."
+            )
+            return
+
+        if not (self._evaluators_path / "evaluators").is_dir():
+            # An explicitly-supplied path that does not hold an evaluators
+            # package is "absent", not "broken" -- keep the two apart.
+            self._evaluators_error = (
+                f"WAA evaluators package not found under the supplied path "
+                f"{self._evaluators_path}."
+            )
             return
 
         # Add to sys.path if not already there
@@ -125,15 +240,9 @@ class EvaluatorClient:
             self._getters = getters
             self._metrics = metrics
         except ImportError as e:
-            # Evaluators not available, will use fallback. Log it: a missing
-            # WAA evaluators package and a broken one both land here, and
-            # silently swallowing the reason made a degraded fallback
-            # evaluation indistinguishable from a healthy one.
-            logger.warning(
-                "WAA evaluators not importable from %s (%s); "
-                "falling back to built-in evaluation",
-                self._evaluators_path,
-                e,
+            self._evaluators_error = (
+                f"WAA evaluators found at {self._evaluators_path} but not "
+                f"importable ({e}) -- the install is broken, not absent."
             )
 
     def evaluate(self, task_config: Dict[str, Any]) -> EvaluationResult:
@@ -146,15 +255,22 @@ class EvaluatorClient:
                 - func: Metric function name (default: 'exact_match')
 
         Returns:
-            EvaluationResult with success status, score, and details.
+            EvaluationResult. Check ``result.scored`` before treating
+            ``result.score`` as a measurement: an unreachable VM or a broken
+            evaluator yields ``score=0.0`` with ``error_type`` set, which is not
+            the same thing as a task the agent failed.
         """
         evaluator_config = task_config.get("evaluator", {})
 
         if not evaluator_config:
+            # A task with no evaluator spec cannot be scored at all. This is a
+            # configuration error, not a task the agent failed.
             return EvaluationResult(
                 success=False,
                 score=0.0,
-                reason="No evaluator configuration in task"
+                reason="No evaluator configuration in task",
+                error_type="evaluation",
+                evaluator_source=self.evaluator_source,
             )
 
         try:
@@ -173,14 +289,27 @@ class EvaluatorClient:
                 actual=actual,
                 expected=expected,
                 reason=f"Metric returned score {score}",
-                metrics={"raw_score": score}
+                metrics={"raw_score": score},
+                evaluator_source=self.evaluator_source,
             )
 
+        except requests.RequestException as e:
+            # The VM never answered. Scoring this 0.0 with no marker is how an
+            # unreachable backend gets published as a legitimate 0%.
+            return EvaluationResult(
+                success=False,
+                score=0.0,
+                reason=f"VM unreachable during evaluation: {e}",
+                error_type="infrastructure",
+                evaluator_source=self.evaluator_source,
+            )
         except Exception as e:
             return EvaluationResult(
                 success=False,
                 score=0.0,
-                reason=f"Evaluation error: {str(e)}"
+                reason=f"Evaluation error: {str(e)}",
+                error_type="evaluation",
+                evaluator_source=self.evaluator_source,
             )
 
     def _get_actual_value(self, evaluator_config: Dict[str, Any]) -> Any:
@@ -199,18 +328,21 @@ class EvaluatorClient:
                 self.timeout = timeout
 
             def execute(self, command: str) -> Dict[str, Any]:
-                """Execute command on VM via HTTP."""
+                """Execute command on VM via HTTP.
+
+                Propagates the transport error rather than returning an empty
+                ``output``: an unreachable VM that returns ``""`` compares equal
+                to nothing and scores 0.0, which is indistinguishable from the
+                command having genuinely produced no output.
+                """
                 url = f"http://{self.vm_ip}:{self.port}/execute"
-                try:
-                    response = requests.post(
-                        url,
-                        json={"command": command},
-                        timeout=self.timeout
-                    )
-                    response.raise_for_status()
-                    return response.json()
-                except requests.RequestException as e:
-                    return {"error": str(e), "output": ""}
+                response = requests.post(
+                    url,
+                    json={"command": command},
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+                return response.json()
 
         env = HttpEnv(self.vm_ip, self.port, self.timeout)
 
@@ -229,26 +361,40 @@ class EvaluatorClient:
         if getter_type == "file_content":
             path = spec.get("path", "")
             result = env.execute(f"type {path}")
-            return result.get("output", "")
+            return self._require_output(result, getter_type)
 
         elif getter_type == "registry_value":
             key = spec.get("key", "")
             value = spec.get("value", "")
             result = env.execute(f'reg query "{key}" /v "{value}"')
-            return result.get("output", "")
+            return self._require_output(result, getter_type)
 
         elif getter_type == "process_running":
             process = spec.get("process", "")
             result = env.execute(f'tasklist /FI "IMAGENAME eq {process}"')
-            return process.lower() in result.get("output", "").lower()
+            return process.lower() in self._require_output(result, getter_type).lower()
 
         elif getter_type == "window_exists":
             title = spec.get("title", "")
             result = env.execute(f'powershell "Get-Process | Where-Object {{$_.MainWindowTitle -like \'*{title}*\'}}"')
-            return bool(result.get("output", "").strip())
+            return bool(self._require_output(result, getter_type).strip())
 
         else:
             raise ValueError(f"Unknown getter type: {getter_type}")
+
+    @staticmethod
+    def _require_output(result: Dict[str, Any], getter_type: str) -> str:
+        """Return the command output, or raise if the VM reported an error.
+
+        ``{"error": ..., "output": ""}`` and ``{"output": ""}`` are not the same
+        thing; treating them alike is how a failed command becomes a measured
+        empty result.
+        """
+        if isinstance(result, dict) and result.get("error"):
+            raise EvaluationError(
+                f"getter '{getter_type}' could not run on the VM: {result['error']}"
+            )
+        return (result or {}).get("output", "") or ""
 
     def _get_expected_value(self, evaluator_config: Dict[str, Any]) -> Any:
         """Extract expected value from evaluator config."""
@@ -266,7 +412,13 @@ class EvaluatorClient:
         return None
 
     def _run_metric(self, evaluator_config: Dict[str, Any], actual: Any, expected: Any) -> float:
-        """Run metric function to compare actual vs expected."""
+        """Run metric function to compare actual vs expected.
+
+        A WAA metric that raises is an evaluation failure, not a reason to
+        quietly re-score the task with a different (built-in) metric: the two
+        metrics do not agree, so substituting one for the other publishes a
+        number nobody asked for.
+        """
         func_name = evaluator_config.get("func", "exact_match")
 
         # Try WAA metric if available
@@ -275,23 +427,39 @@ class EvaluatorClient:
             if metric_func:
                 try:
                     return float(metric_func(actual, expected))
-                except Exception:
-                    pass
+                except Exception as e:
+                    raise EvaluationError(
+                        f"WAA metric '{func_name}' raised while scoring: {e}"
+                    ) from e
 
         # Fallback metrics
         return self._fallback_metric(func_name, actual, expected)
 
     def _fallback_metric(self, func_name: str, actual: Any, expected: Any) -> float:
-        """Fallback metric — delegates to shared evaluation.metrics module."""
-        from openadapt_evals.evaluation.metrics import exact_match, get_metric
+        """Fallback metric — delegates to shared evaluation.metrics module.
+
+        An unknown metric name raises. Silently substituting ``exact_match``
+        scores the task with the wrong comparison and reports the result as if
+        the requested metric had run.
+        """
+        from openadapt_evals.evaluation.metrics import get_metric
 
         metric_fn = get_metric(func_name)
-        if metric_fn is not None:
-            return float(metric_fn(actual, expected))
-        return float(exact_match(actual, expected))
+        if metric_fn is None:
+            raise EvaluationError(
+                f"metric '{func_name}' is not implemented by the built-in "
+                f"fallback evaluator; scoring with a different metric would "
+                f"publish a number the task config did not ask for"
+            )
+        return float(metric_fn(actual, expected))
 
     def health_check(self) -> bool:
-        """Check if WAA server is reachable."""
+        """Check if WAA server is reachable.
+
+        A False here means "probed and did not get a healthy answer", which is
+        the honest answer to the question this method asks; it is not used as a
+        task score.
+        """
         try:
             response = requests.get(
                 f"{self.base_url}/probe",

--- a/openadapt_evals/flow/parallels_env.py
+++ b/openadapt_evals/flow/parallels_env.py
@@ -62,7 +62,12 @@ DEFAULT_VM_UUID = "d4f9c29a-52e1-4793-9334-7e971c3d0ab3"
 DEFAULT_AGENT_PORT = 5000
 
 # A verifier: (vm) -> (success, reason). Reads ground-truth in-guest state.
-VerifyFn = Callable[[Any], "tuple[bool, Optional[str]]"]
+# A verifier returns (verdict, reason). `verdict is None` means the check
+# could not be performed at all -- the exec channel failed, the guest agent is
+# dead, the VM was reverted -- which the runner records as UNSCORED rather than
+# as a failed task. Returning False for "I could not look" pins the verified
+# success rate at 0% regardless of ground truth.
+VerifyFn = Callable[[Any], "tuple[Optional[bool], Optional[str]]"]
 
 
 def parallels_enabled(config: "Optional[ParallelsConfig]" = None) -> bool:
@@ -107,23 +112,53 @@ _NOTEPAD_OUT = r"C:\oa\eval\notepad_out.txt"
 _NOTEPAD_EXPECTED = "openadapt-flow replay ok"
 
 
+def _exec_output(proc: Any, what: str) -> "tuple[Optional[str], Optional[str]]":
+    """Return ``(stdout, None)`` or ``(None, why_it_could_not_be_read)``.
+
+    ``exec_ps``/``exec_cmd`` hand back a CompletedProcess-shaped object whose
+    ``returncode`` used to be discarded. A dead ``win_agent``, a ``prlctl``
+    failure, an auth rejection and a reverted VM all produce empty stdout,
+    which then compares unequal to the expected value and is recorded as the
+    task having failed -- ground-truth verification silently degrading into a
+    measured failure.
+    """
+    returncode = getattr(proc, "returncode", None)
+    if returncode not in (0, None):
+        stderr = (getattr(proc, "stderr", "") or "").strip()[:200]
+        return None, f"{what} could not run (exit {returncode}): {stderr!r}"
+    return (getattr(proc, "stdout", "") or ""), None
+
+
 def verify_notepad_file(
     vm: Any, *, path: str = _NOTEPAD_OUT, expected: str = _NOTEPAD_EXPECTED
-) -> "tuple[bool, Optional[str]]":
+) -> "tuple[Optional[bool], Optional[str]]":
     """Success iff the Notepad task wrote ``expected`` into ``path`` in-guest."""
     ps = f"if (Test-Path '{path}') {{ Get-Content -Raw '{path}' }} else {{ 'MISSING' }}"
     proc = vm.exec_ps(ps)
-    out = (getattr(proc, "stdout", "") or "").strip()
+    out, unavailable = _exec_output(proc, "notepad file read")
+    if unavailable is not None:
+        return None, unavailable
+    out = out.strip()
     ok = expected in out
     return ok, f"notepad file contents: {out!r}"
 
 
-def verify_calculator_open(vm: Any) -> "tuple[bool, Optional[str]]":
+def verify_calculator_open(vm: Any) -> "tuple[Optional[bool], Optional[str]]":
     """Success iff a Calculator window/process is present in-guest (trivial check)."""
-    proc = vm.exec_cmd('tasklist /FI "IMAGENAME eq CalculatorApp.exe" /FI "IMAGENAME eq Calculator.exe"')
-    out = (getattr(proc, "stdout", "") or "")
-    ok = "alculator" in out
-    return ok, f"tasklist: {out.strip()[:120]!r}"
+    # One /FI per call: `tasklist` ANDs multiple IMAGENAME filters, so asking
+    # for CalculatorApp.exe AND Calculator.exe is unsatisfiable and always
+    # prints "No tasks are running which match" -- this check could never
+    # return True, pinning the task's verified success rate at 0%.
+    reasons = []
+    for image in ("CalculatorApp.exe", "Calculator.exe"):
+        proc = vm.exec_cmd(f'tasklist /FI "IMAGENAME eq {image}"')
+        out, unavailable = _exec_output(proc, "tasklist")
+        if unavailable is not None:
+            return None, unavailable
+        reasons.append(f"{image}: {out.strip()[:80]!r}")
+        if "alculator" in out:
+            return True, f"tasklist: {out.strip()[:120]!r}"
+    return False, "tasklist: " + "; ".join(reasons)
 
 
 def builtin_tasks(bundles_dir: Optional[Path] = None) -> list[ParallelsTask]:
@@ -270,10 +305,12 @@ def make_parallels_evaluator(
 ) -> "Callable[[str], tuple[bool, Optional[str]]]":
     """Build a WAA-style verifier callable over our built-in ground-truth checks."""
 
-    def _evaluate(task_id: str) -> "tuple[bool, Optional[str]]":
+    def _evaluate(task_id: str) -> "tuple[Optional[bool], Optional[str]]":
         task = tasks_by_id.get(task_id)
         if task is None:
-            return False, f"unknown parallels task {task_id!r}"
+            # We were never asked to score a task we know about; that is a
+            # harness bug, not a task the replay failed.
+            return None, f"unknown parallels task {task_id!r}"
         return task.verify(vm)
 
     return _evaluate

--- a/openadapt_evals/flow/replay_runner.py
+++ b/openadapt_evals/flow/replay_runner.py
@@ -248,7 +248,13 @@ def run_demonstrate_then_replay(
         if evaluator is not None:
             try:
                 verified, reason = evaluator(task.task_id)
-                metrics.waa_verified_success = bool(verified)
+                # `None` means the verifier could not run. Leave
+                # waa_verified_success unset so aggregate_replay_metrics
+                # excludes this task from the rate's denominator rather than
+                # counting an unperformed check as a failure.
+                metrics.waa_verified_success = (
+                    None if verified is None else bool(verified)
+                )
                 if reason and not metrics.error:
                     metrics.error = reason if not verified else None
             except Exception as e:  # noqa: BLE001

--- a/openadapt_evals/harness/inspect_export.py
+++ b/openadapt_evals/harness/inspect_export.py
@@ -21,9 +21,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-# Inspect's canonical value for a correct/incorrect boolean score.
+# Inspect's canonical values for a correct/incorrect boolean score, plus
+# NOANSWER for a sample the scorer could not score at all. A row whose env
+# verifier never ran is NOANSWER, not INCORRECT: counting it as incorrect
+# publishes an accuracy whose denominator includes tasks nobody measured.
 _CORRECT = "C"
 _INCORRECT = "I"
+_NOANSWER = "N"
 
 _SCHEMA_VERSION = 2  # Inspect eval-log major version this subset targets.
 
@@ -61,7 +65,11 @@ def to_inspect_eval_log(
 
     samples = []
     for i, r in enumerate(dict_rows):
-        success = bool(r.get("replay_success", False))
+        replay_success = r.get("replay_success", False)
+        if replay_success is None:
+            value = _NOANSWER
+        else:
+            value = _CORRECT if bool(replay_success) else _INCORRECT
         samples.append(
             {
                 "id": r.get("task_id", f"sample_{i}"),
@@ -70,9 +78,9 @@ def to_inspect_eval_log(
                 "target": _CORRECT,
                 "scores": {
                     "meta_verifier": {
-                        "value": _CORRECT if success else _INCORRECT,
+                        "value": value,
                         "answer": str(r.get("effect_verdict") or r.get("verifier_source") or ""),
-                        "explanation": r.get("error") or "",
+                        "explanation": r.get("verifier_error") or r.get("error") or "",
                         "metadata": {
                             "env": r.get("env"),
                             "mode": r.get("mode"),
@@ -89,11 +97,18 @@ def to_inspect_eval_log(
         )
 
     total = len(samples)
-    correct = sum(1 for s in samples if s["scores"]["meta_verifier"]["value"] == _CORRECT)
+    values = [s["scores"]["meta_verifier"]["value"] for s in samples]
+    unscored = sum(1 for v in values if v == _NOANSWER)
+    scored = total - unscored
+    correct = sum(1 for v in values if v == _CORRECT)
+    # None, not 0.0: an accuracy of zero and "nothing was scored" are different
+    # claims, and only one of them is a measurement.
+    accuracy = (correct / scored) if scored else None
 
     return {
         "version": _SCHEMA_VERSION,
-        "status": "success",
+        # A run in which nothing could be scored did not succeed.
+        "status": "success" if scored else "error",
         "eval": {
             "task": task_name,
             "model": model,
@@ -102,7 +117,9 @@ def to_inspect_eval_log(
         },
         "results": {
             "total_samples": total,
-            "completed_samples": total,
+            # Only rows the env verifier actually scored are "completed".
+            "completed_samples": scored,
+            "unscored_samples": unscored,
             "scores": [
                 {
                     "name": "meta_verifier",
@@ -110,7 +127,9 @@ def to_inspect_eval_log(
                     "metrics": {
                         "accuracy": {
                             "name": "accuracy",
-                            "value": (correct / total) if total else 0.0,
+                            "value": accuracy,
+                            "scored_samples": scored,
+                            "unscored_samples": unscored,
                         }
                     },
                 }
@@ -140,7 +159,11 @@ def from_inspect_eval_log(doc: dict) -> "list[dict]":
                 "task_id": sample.get("id"),
                 "env": smeta.get("env"),
                 "mode": smeta.get("mode"),
-                "replay_success": score.get("value") == _CORRECT,
+                "replay_success": (
+                    None
+                    if score.get("value") == _NOANSWER
+                    else score.get("value") == _CORRECT
+                ),
                 "effect_verdict": score.get("answer") or None,
                 "model_calls": smeta.get("model_calls"),
                 "structural_rung_rate": smeta.get("structural_rung_rate"),

--- a/openadapt_evals/harness/runner.py
+++ b/openadapt_evals/harness/runner.py
@@ -103,7 +103,11 @@ class MetaMetricsRow:
     env: str
     task_id: str
     mode: str
-    replay_success: bool
+    #: Tri-state. ``True``/``False`` are the verifier's verdict; ``None`` means
+    #: the verifier did not run, which is NOT a failure. ``flow/replay_runner``
+    #: already models unscored tasks this way and excludes them from its rate;
+    #: this row must too, or a crashed verifier is published as a failed task.
+    replay_success: Optional[bool]
     structural_rung_rate: float
     model_calls: int
     effect_verdict: Optional[str]
@@ -111,19 +115,30 @@ class MetaMetricsRow:
     cost_usd: float
     # Diagnostics (never override replay_success).
     reported_success: bool = False
-    verifier_score: float = 0.0
+    #: ``None`` when ``replay_success`` is ``None`` -- there is no score.
+    verifier_score: Optional[float] = 0.0
     verifier_source: Optional[str] = None
+    #: Why the verifier could not produce a verdict, when it could not.
+    verifier_error: Optional[str] = None
     num_steps: int = 0
     heal_count: int = 0
     structural_rung_counts: dict[str, int] = field(default_factory=dict)
     error: Optional[str] = None
+
+    @property
+    def scored(self) -> bool:
+        """True only when the env verifier actually produced a verdict."""
+        return self.replay_success is not None
 
     def as_dict(self) -> dict:
         d = asdict(self)
         d["structural_rung_rate"] = round(self.structural_rung_rate, 4)
         d["wall_ms"] = round(self.wall_ms, 2)
         d["cost_usd"] = round(self.cost_usd, 6)
-        d["verifier_score"] = round(self.verifier_score, 4)
+        d["verifier_score"] = (
+            round(self.verifier_score, 4) if self.verifier_score is not None else None
+        )
+        d["scored"] = self.scored
         return d
 
 
@@ -170,18 +185,33 @@ def run_meta(
         error = str(e)
 
     # Ground truth: the ENV's own verifier, never the policy's self-report.
+    # A verifier that CRASHED did not say "the task failed" -- it said nothing.
+    # Collapsing that into replay_success=False / verifier_score=0.0 makes an
+    # unscored task indistinguishable from a scored failure, and the accuracy
+    # computed over these rows silently gains a wrong denominator.
     verifier_result = None
+    verifier_error: Optional[str] = None
     try:
         verifier_result = env.verify(task)
+        if verifier_result is None:
+            verifier_error = "verify() returned None"
     except Exception as e:  # noqa: BLE001
         logger.warning("verify() failed for %s: %s", getattr(task, "task_id", "?"), e)
-        error = error or f"verify error: {e}"
+        verifier_error = f"verify error: {e}"
+        # Keep the verify failure even when the policy already errored; `error`
+        # used to swallow it whole via `error = error or ...`.
+        error = f"{error}; {verifier_error}" if error else verifier_error
 
     wall_ms = (time.monotonic() - start) * 1000.0
 
-    success = bool(getattr(verifier_result, "success", False))
-    score = float(getattr(verifier_result, "score", 0.0) or 0.0)
-    details = getattr(verifier_result, "details", {}) or {}
+    if verifier_error is not None:
+        success: Optional[bool] = None
+        score: Optional[float] = None
+        details: dict = {}
+    else:
+        success = bool(getattr(verifier_result, "success", False))
+        score = float(getattr(verifier_result, "score", 0.0) or 0.0)
+        details = getattr(verifier_result, "details", {}) or {}
 
     row = MetaMetricsRow(
         env=env_name,
@@ -196,6 +226,7 @@ def run_meta(
         reported_success=outcome.reported_success,
         verifier_score=score,
         verifier_source=details.get("source"),
+        verifier_error=verifier_error,
         num_steps=outcome.num_steps,
         heal_count=outcome.heal_count,
         structural_rung_counts=dict(outcome.structural_rung_counts),

--- a/openadapt_evals/infrastructure/aws_vm.py
+++ b/openadapt_evals/infrastructure/aws_vm.py
@@ -596,11 +596,24 @@ class AWSVMManager:
                 return False
 
             minutes = hours * 60
-            ssh_run(
+            proc = ssh_run(
                 ip,
                 f"sudo shutdown -h +{minutes}",
                 username=self.ssh_username,
             )
+            # `ssh_run` does not raise on a non-zero exit. Returning True
+            # without checking asserted that the cost safety net was armed when
+            # it may not have been -- and the instance then bills until someone
+            # notices.
+            returncode = getattr(proc, "returncode", None)
+            if returncode not in (0, None):
+                logger.error(
+                    "Auto-shutdown NOT set for %s: `shutdown` exited %s: %s",
+                    name,
+                    returncode,
+                    (getattr(proc, "stderr", "") or "").strip()[:300],
+                )
+                return False
             logger.info(f"Auto-shutdown set for {name} in {hours} hours")
             return True
 

--- a/openadapt_evals/infrastructure/resource_tracker.py
+++ b/openadapt_evals/infrastructure/resource_tracker.py
@@ -105,8 +105,23 @@ def get_active_pool_warning() -> str | None:
     return None
 
 
+class AzureQueryFailed(RuntimeError):
+    """An ``az`` query did not run, so its result set is unknown.
+
+    An empty list from a failed query and an empty list from an empty
+    subscription are the same value, and the caller turns that value into the
+    positive claim "All Azure resources are deallocated or stopped" -- while
+    VMs keep billing.
+    """
+
+
 def get_azure_vms() -> list[dict]:
-    """Get all VMs in the resource group."""
+    """Get all VMs in the resource group.
+
+    Raises:
+        AzureQueryFailed: If ``az`` could not be run or its output could not be
+            parsed. Callers must not treat that as "no VMs".
+    """
     try:
         result = subprocess.run(
             ["az", "vm", "list", "-g", RESOURCE_GROUP, "--show-details", "-o", "json"],
@@ -114,16 +129,30 @@ def get_azure_vms() -> list[dict]:
             text=True,
             timeout=30,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return json.loads(result.stdout)
-    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-        pass
-    return []
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        raise AzureQueryFailed(f"could not run `az vm list`: {e}") from e
+
+    if result.returncode != 0:
+        raise AzureQueryFailed(
+            f"`az vm list` exited {result.returncode}: "
+            f"{(result.stderr or '').strip()[:300]}"
+        )
+    if not result.stdout.strip():
+        raise AzureQueryFailed("`az vm list` produced no output")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise AzureQueryFailed(f"`az vm list` output was not JSON: {e}") from e
 
 
 def get_azure_ml_compute() -> list[dict]:
-    """Get Azure ML compute instances from all known workspaces."""
-    all_compute = []
+    """Get Azure ML compute instances from all known workspaces.
+
+    Raises:
+        AzureQueryFailed: If no workspace could be queried at all.
+    """
+    all_compute: list[dict] = []
+    failures: list[str] = []
 
     # Try to get workspaces from settings, fall back to known defaults
     try:
@@ -163,13 +192,37 @@ def get_azure_ml_compute() -> list[dict]:
                 text=True,
                 timeout=30,
             )
-            if result.returncode == 0 and result.stdout.strip():
-                compute_list = json.loads(result.stdout)
-                for ci in compute_list:
-                    ci["_workspace"] = workspace_name
-                all_compute.extend(compute_list)
-        except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
-            pass
+            if result.returncode != 0:
+                # A workspace that does not exist in this subscription is a
+                # normal, expected miss; record it so the caller can tell that
+                # from a workspace we simply failed to query.
+                failures.append(
+                    f"az ml compute list -g {resource_group} -w {workspace_name} "
+                    f"exited {result.returncode}"
+                )
+                continue
+            if not result.stdout.strip():
+                failures.append(
+                    f"az ml compute list -w {workspace_name} produced no output"
+                )
+                continue
+            compute_list = json.loads(result.stdout)
+            for ci in compute_list:
+                ci["_workspace"] = workspace_name
+            all_compute.extend(compute_list)
+        except (
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+            FileNotFoundError,
+        ) as e:
+            failures.append(f"workspace {workspace_name}: {e}")
+
+    if failures and not all_compute:
+        # Every workspace query failed and we found nothing. That is not
+        # evidence that nothing is running.
+        raise AzureQueryFailed(
+            "no Azure ML workspace could be queried: " + "; ".join(failures)
+        )
 
     return all_compute
 
@@ -185,10 +238,17 @@ def check_resources() -> dict:
         "has_running_resources": False,
         "has_paused_pool": False,
         "warnings": [],
+        # Non-empty means at least one probe did not run. While this is
+        # non-empty the report must NOT claim that nothing is running.
+        "query_failures": [],
     }
 
     # Check VMs
-    vms = get_azure_vms()
+    try:
+        vms = get_azure_vms()
+    except AzureQueryFailed as e:
+        vms = []
+        status["query_failures"].append(str(e))
     for vm in vms:
         name = vm.get("name", "unknown")
         power_state = vm.get("powerState", "unknown")
@@ -217,7 +277,11 @@ def check_resources() -> dict:
             )
 
     # Check Azure ML compute
-    compute_instances = get_azure_ml_compute()
+    try:
+        compute_instances = get_azure_ml_compute()
+    except AzureQueryFailed as e:
+        compute_instances = []
+        status["query_failures"].append(str(e))
     for ci in compute_instances:
         name = ci.get("name", "unknown")
         state = ci.get("state", "unknown")
@@ -281,6 +345,20 @@ def update_resources_file(status: dict) -> None:
 
         for warning in status["warnings"]:
             lines.append(f"- {warning}")
+        lines.append("")
+    elif status.get("query_failures"):
+        lines.extend(
+            [
+                "## Resource State UNKNOWN",
+                "",
+                "One or more Azure queries did not run, so this file cannot "
+                "say whether anything is running. Resources may still be "
+                "billing.",
+                "",
+            ]
+        )
+        for failure in status["query_failures"]:
+            lines.append(f"- {failure}")
         lines.append("")
     else:
         lines.extend(

--- a/openadapt_evals/server/evaluate_endpoint.py
+++ b/openadapt_evals/server/evaluate_endpoint.py
@@ -32,6 +32,21 @@ from typing import Any, Callable
 
 logger = logging.getLogger(__name__)
 
+
+class EvaluationNotRunError(RuntimeError):
+    """The evaluation could not be carried out, as opposed to failing.
+
+    Every path that used to answer a broken getter or a raising metric with
+    ``score=0.0`` raises this instead. The endpoint turns it into a response
+    carrying ``scored: false`` and an ``error_type``, so an unreachable VM is
+    never accepted upstream as a legitimate 0% benchmark result.
+    """
+
+    def __init__(self, message: str, error_type: str = "evaluation") -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
 # Try to import Flask for blueprint creation
 try:
     from flask import Blueprint, jsonify, request
@@ -144,14 +159,22 @@ def get_actual_value(
     getter_func = getattr(getters, getter_name, None)
 
     if getter_func is None:
-        logger.warning(f"Getter not found: {getter_name}")
-        return None
+        # A getter the deployed evaluators do not implement cannot score this
+        # task. Returning None made it compare unequal to `expected` and score
+        # 0.0, which reads downstream as "the agent failed".
+        raise EvaluationNotRunError(
+            f"getter '{getter_name}' is not implemented by the deployed WAA "
+            f"evaluators; the task was not scored"
+        )
 
     try:
         return getter_func(env, result_spec)
     except Exception as e:
         logger.error(f"Getter {getter_name} failed: {e}")
-        return None
+        raise EvaluationNotRunError(
+            f"getter '{getter_name}' raised while reading the VM: {e}",
+            error_type="infrastructure",
+        ) from e
 
 
 def get_expected_value(
@@ -243,26 +266,22 @@ def run_metric(
     metric_func = getattr(metrics, metric_name, None)
 
     if metric_func is None:
-        # Try common fallbacks
-        fallbacks = ["exact_match", "fuzzy_match"]
-        for fallback in fallbacks:
-            metric_func = getattr(metrics, fallback, None)
-            if metric_func:
-                logger.warning(
-                    f"Metric '{metric_name}' not found, using '{fallback}'"
-                )
-                break
-
-    if metric_func is None:
-        logger.error(f"No valid metric found for '{metric_name}'")
-        return 0.0
+        # Substituting exact_match for a metric the task asked for scores the
+        # task with a different comparison and reports it as if the requested
+        # metric had run. "Metric not implemented" is not "the agent failed".
+        raise EvaluationNotRunError(
+            f"metric '{metric_name}' is not implemented by the deployed WAA "
+            f"evaluators; refusing to substitute a different metric"
+        )
 
     try:
         score = metric_func(actual, expected, **options)
         return float(score)
     except Exception as e:
         logger.error(f"Metric {metric_name} failed: {e}")
-        return 0.0
+        raise EvaluationNotRunError(
+            f"metric '{metric_name}' raised while scoring: {e}"
+        ) from e
 
 
 def evaluate_task_state(
@@ -302,21 +321,12 @@ def evaluate_task_state(
     try:
         getters, metrics = _load_waa_evaluators(evaluators_path)
     except ImportError as e:
-        return {
-            "success": False,
-            "score": 0.0,
-            "reason": f"Failed to load evaluators: {e}",
-            "error": str(e),
-        }
+        return _not_scored(f"Failed to load evaluators: {e}", "evaluation")
 
     evaluator_config = task_config.get("evaluator", {})
 
     if not evaluator_config:
-        return {
-            "success": False,
-            "score": 0.0,
-            "reason": "No evaluator configuration in task",
-        }
+        return _not_scored("No evaluator configuration in task", "evaluation")
 
     # Handle infeasible tasks
     # If task is marked infeasible and agent reported FAIL, that's success
@@ -336,10 +346,13 @@ def evaluate_task_state(
         _run_postconfig(postconfig, env)
 
     # Get actual value from VM
-    actual = get_actual_value(evaluator_config, env, getters)
+    try:
+        actual = get_actual_value(evaluator_config, env, getters)
 
-    # Get expected value
-    expected = get_expected_value(evaluator_config, env, getters)
+        # Get expected value
+        expected = get_expected_value(evaluator_config, env, getters)
+    except EvaluationNotRunError as e:
+        return _not_scored(str(e), e.error_type)
 
     # Get metric function(s)
     func_spec = evaluator_config.get("func", "exact_match")
@@ -355,7 +368,10 @@ def evaluate_task_state(
     # Run each metric
     metric_results = []
     for func_name in func_names:
-        score = run_metric(func_name, actual, expected, options, metrics)
+        try:
+            score = run_metric(func_name, actual, expected, options, metrics)
+        except EvaluationNotRunError as e:
+            return _not_scored(str(e), e.error_type)
         metric_results.append({
             "metric": func_name,
             "score": score,
@@ -364,11 +380,9 @@ def evaluate_task_state(
 
     # Guard empty metric_results (e.g. func_spec was [])
     if not metric_results:
-        return {
-            "success": False,
-            "score": 0.0,
-            "reason": "No metrics could be computed (empty func spec)",
-        }
+        return _not_scored(
+            "No metrics could be computed (empty func spec)", "evaluation",
+        )
 
     # Combine results based on conjunction
     if conjunction == "or":
@@ -399,6 +413,26 @@ def evaluate_task_state(
         "expected": expected_str,
         "reason": reason,
         "metrics": metric_results if len(metric_results) > 1 else None,
+        # This one IS a measurement.
+        "scored": True,
+        "error_type": None,
+    }
+
+
+def _not_scored(reason: str, error_type: str) -> dict:
+    """Build a response for a task that was NOT scored.
+
+    ``score``/``success`` are present for schema compatibility with old
+    consumers, but ``scored: false`` is the field that matters: nothing here
+    was measured, and aggregating this row as a zero publishes a wrong number.
+    """
+    logger.error("evaluation not run (%s): %s", error_type, reason)
+    return {
+        "success": False,
+        "score": 0.0,
+        "reason": reason,
+        "scored": False,
+        "error_type": error_type,
     }
 
 

--- a/scripts/check_published_evidence_freshness.py
+++ b/scripts/check_published_evidence_freshness.py
@@ -199,6 +199,21 @@ def main(argv: list[str] | None = None) -> int:
         for problem in problems:
             print(f"DRIFT: {problem}", file=sys.stderr)
         return 1
+
+    if release_version is None:
+        # The release-freshness comparison did not run. Skipping it is
+        # deliberate (see the module docstring) and the exit code stays 0, but
+        # the message must not claim the binding was verified: in a CI log
+        # where only the last line is read, that reads as a passing freshness
+        # check when the check never happened.
+        print(
+            f"Published evidence {entry['path']} passed its OFFLINE checks. "
+            f"The release-freshness comparison against the current {package} "
+            f"release was SKIPPED"
+            + (" (--offline)." if args.offline else " (PyPI unreachable).")
+        )
+        return 0
+
     print(
         f"Published evidence {entry['path']} is bound to the current "
         f"{package} release {entry['flow_version']}."

--- a/scripts/compare_models.py
+++ b/scripts/compare_models.py
@@ -236,7 +236,7 @@ def run_single_task(
     screenshots_dir: Path | None,
 ) -> dict[str, Any]:
     """Run a single task and return a result dict. Never raises."""
-    from openadapt_evals.adapters.base import BenchmarkTask
+    from openadapt_evals.adapters.base import BenchmarkTask, EvaluationUnavailableError
     from openadapt_evals.adapters.rl_env import ResetConfig, RLEnvironment
     from openadapt_evals.adapters.waa.live import WAALiveAdapter, WAALiveConfig
     from openadapt_evals.task_config import TaskConfig
@@ -254,6 +254,10 @@ def run_single_task(
         "steps": 0,
         "actions": [],
         "error": None,
+        # None means "this row is a measurement". Anything else means the task
+        # was not scored and `score` must be excluded from the matrix rather
+        # than rendered as a 0.00 cell in a head-to-head model comparison.
+        "error_type": None,
     }
     try:
         adapter = WAALiveAdapter(WAALiveConfig(server_url=server_url))
@@ -321,8 +325,14 @@ def run_single_task(
         else:
             score = env.evaluate()
         result["score"] = score
+    except EvaluationUnavailableError as e:
+        result["error"] = str(e)
+        result["error_type"] = e.error_type
+        result["traceback"] = traceback.format_exc()
+        logger.error("Task %s was not scored: %s", task_path, e)
     except Exception as e:
         result["error"] = str(e)
+        result["error_type"] = "infrastructure"
         result["traceback"] = traceback.format_exc()
         logger.error("Task %s failed: %s", task_path, e)
 
@@ -549,6 +559,11 @@ def build_summary(results: list[dict], config: ComparisonConfig) -> dict:
     matrix: dict[str, dict[str, float]] = {}
     steps_matrix: dict[str, dict[str, int]] = {}
     time_matrix: dict[str, dict[str, float]] = {}
+    # Rows that were never scored. Averaging their 0.0 into avg_score would
+    # make a model whose SGLang server failed to start look worse than one
+    # whose server came up -- a pure-infrastructure delta published as a
+    # capability delta.
+    unscored: dict[str, dict[str, str]] = {}
     for r in results:
         model = r.get("model_name", "unknown")
         task = r.get("task_path", "unknown")
@@ -556,6 +571,10 @@ def build_summary(results: list[dict], config: ComparisonConfig) -> dict:
             matrix[model] = {}
             steps_matrix[model] = {}
             time_matrix[model] = {}
+            unscored[model] = {}
+        if r.get("error_type"):
+            unscored[model][task] = str(r.get("error_type"))
+            continue
         matrix[model][task] = r.get("score", 0.0)
         steps_matrix[model][task] = r.get("steps", 0)
         time_matrix[model][task] = r.get("elapsed_seconds", 0.0)
@@ -563,10 +582,13 @@ def build_summary(results: list[dict], config: ComparisonConfig) -> dict:
     for model, scores in matrix.items():
         vals = list(scores.values())
         model_averages[model] = {
-            "avg_score": sum(vals) / len(vals) if vals else 0.0,
-            "avg_steps": sum(steps_matrix[model].values()) / len(vals) if vals else 0.0,
-            "avg_time": sum(time_matrix[model].values()) / len(vals) if vals else 0.0,
+            # None, not 0.0: no task of this model's produced a measurement.
+            "avg_score": sum(vals) / len(vals) if vals else None,
+            "avg_steps": sum(steps_matrix[model].values()) / len(vals) if vals else None,
+            "avg_time": sum(time_matrix[model].values()) / len(vals) if vals else None,
             "total_runs": len(vals),
+            "unscored_runs": len(unscored.get(model, {})),
+            "unscored_tasks": unscored.get(model, {}),
         }
     return {
         "comparison_name": config.name,
@@ -579,6 +601,17 @@ def build_summary(results: list[dict], config: ComparisonConfig) -> dict:
         "time_matrix": time_matrix,
         "model_averages": model_averages,
     }
+
+
+def _fmt_avg(value: float | None, width: int, precision: int, suffix: str = "") -> str:
+    """Render an average, or `--` when nothing was scored.
+
+    Printing 0.00 for "no task of this model produced a measurement" is the
+    defect this whole module is being repaired for.
+    """
+    if value is None:
+        return f"{'--':>{width}}{suffix}"
+    return f"{value:>{width}.{precision}f}{suffix}"
 
 
 def print_summary_table(summary: dict) -> None:
@@ -610,9 +643,12 @@ def print_summary_table(summary: dict) -> None:
             else:
                 row += f"  {'--':>{task_col_w}}"
         avg = averages.get(model, {})
-        row += f"  {avg.get('avg_score', 0.0):>6.2f}"
-        row += f"  {avg.get('avg_steps', 0.0):>5.1f}"
-        row += f"  {avg.get('avg_time', 0.0):>5.1f}s"
+        row += "  " + _fmt_avg(avg.get("avg_score"), 6, 2)
+        row += "  " + _fmt_avg(avg.get("avg_steps"), 5, 1)
+        row += "  " + _fmt_avg(avg.get("avg_time"), 5, 1, "s")
+        unscored_n = avg.get("unscored_runs", 0)
+        if unscored_n:
+            row += f"  [{unscored_n} unscored]"
         print(row)
     print("=" * 70)
 
@@ -635,15 +671,19 @@ def generate_html_report(summary: dict, results: list[dict], output_path: Path) 
             else:
                 cells += "<td>--</td>"
         avg = averages.get(model, {})
-        cells += f"<td><strong>{avg.get('avg_score', 0.0):.2f}</strong></td>"
-        cells += f"<td>{avg.get('avg_steps', 0.0):.1f}</td>"
-        cells += f"<td>{avg.get('avg_time', 0.0):.1f}s</td>"
+        cells += (
+            f"<td><strong>{_fmt_avg(avg.get('avg_score'), 0, 2).strip()}"
+            f"</strong></td>"
+        )
+        cells += f"<td>{_fmt_avg(avg.get('avg_steps'), 0, 1).strip()}</td>"
+        cells += f"<td>{_fmt_avg(avg.get('avg_time'), 0, 1, 's').strip()}</td>"
         rows_html += f"<tr>{cells}</tr>\n"
     task_headers = "".join(f"<th>{html.escape(t)}</th>" for t in task_labels)
     details_html = ""
     for r in results:
         model = r.get("model_name", "?")
         task_name = r.get("task_name", r.get("task_path", "?"))
+        unscored_reason = r.get("error_type")
         score = r.get("score", 0.0)
         steps = r.get("steps", 0)
         elapsed = r.get("elapsed_seconds", 0.0)
@@ -656,7 +696,12 @@ def generate_html_report(summary: dict, results: list[dict], output_path: Path) 
                 f"{html.escape(str(a.get('type', '?')))} "
                 f"({html.escape(str(a.get('text', '') or ''))})</li>\n"
             )
-        css = "pass" if score > 0 else "fail"
+        if unscored_reason:
+            css = "unscored"
+            score_text = f"NOT SCORED ({html.escape(str(unscored_reason))})"
+        else:
+            css = "pass" if score > 0 else "fail"
+            score_text = f"score={score:.2f}"
         error_block = ""
         if error:
             error_block = f"<p class='error'>Error: {html.escape(error)}</p>"
@@ -665,7 +710,7 @@ def generate_html_report(summary: dict, results: list[dict], output_path: Path) 
             <summary class="{css}">
                 <strong>{html.escape(model)}</strong> on
                 <em>{html.escape(task_name)}</em>:
-                score={score:.2f}, steps={steps}, time={elapsed:.1f}s
+                {score_text}, steps={steps}, time={elapsed:.1f}s
             </summary>
             <div class="detail-content">
                 {error_block}

--- a/tests/test_evaluator_client_failure_visibility.py
+++ b/tests/test_evaluator_client_failure_visibility.py
@@ -1,0 +1,181 @@
+"""Regression tests: EvaluatorClient must not render a failure as a result.
+
+The reported defect: ``_load_evaluators`` swallowed ``ImportError``, so a broken
+WAA evaluators install and a healthy one produced the same client, and every
+later run was silently scored by the built-in fallback evaluator. PR #275 added
+a ``logger.warning`` and returned the same fallback-configured client, which is
+the same bug with better documentation -- a caller still could not tell.
+
+Each test here fails against the pre-fix (log-only) implementation.
+"""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+
+import pytest
+import requests
+
+from openadapt_evals.evaluation.client import (
+    EvaluationError,
+    EvaluationResult,
+    EvaluatorClient,
+    EvaluatorsUnavailableError,
+)
+
+
+@pytest.fixture
+def broken_evaluators(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A WAA evaluators tree that is present on disk but raises on import.
+
+    This is the *broken install* case, which is what must be distinguishable
+    from the legitimately-absent optional case.
+    """
+    desktop_env = tmp_path / "desktop_env"
+    evaluators = desktop_env / "evaluators"
+    evaluators.mkdir(parents=True)
+    (evaluators / "__init__.py").write_text("")
+    (evaluators / "getters.py").write_text("")
+
+    real_import = builtins.__import__
+
+    def _raising_import(name, *args, **kwargs):
+        if name == "evaluators":
+            raise ImportError("cannot import name 'getters' from 'evaluators'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _raising_import)
+    return desktop_env
+
+
+def test_broken_evaluators_install_raises_instead_of_silently_falling_back(
+    broken_evaluators: Path,
+) -> None:
+    """A present-but-unimportable evaluators package must not construct a client.
+
+    Pre-fix this returned a perfectly usable client whose every result was
+    fallback-scored, with nothing in the object or in any result recording it.
+    """
+    with pytest.raises(EvaluatorsUnavailableError) as excinfo:
+        EvaluatorClient(vm_ip="10.0.0.1", waa_evaluators_path=broken_evaluators)
+
+    message = str(excinfo.value)
+    assert "not importable" in message
+    assert "the install is broken, not absent" in message
+    assert str(broken_evaluators) in message
+
+
+def test_missing_evaluators_reports_absent_not_broken(tmp_path: Path) -> None:
+    """The absent case must be reported differently from the broken case."""
+    with pytest.raises(EvaluatorsUnavailableError) as excinfo:
+        EvaluatorClient(vm_ip="10.0.0.1", waa_evaluators_path=tmp_path / "nope")
+
+    message = str(excinfo.value)
+    assert "not importable" in message or "not found" in message
+    # Distinguishable from the broken-install wording.
+    assert "the install is broken, not absent" not in message
+
+
+def test_deliberate_fallback_is_opt_in_and_stamped_on_every_result(
+    broken_evaluators: Path,
+) -> None:
+    """Opting into fallback scoring is allowed, but never invisible."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=broken_evaluators,
+        require_waa_evaluators=False,
+    )
+
+    assert client.evaluator_source == "fallback"
+    assert client.evaluators_error is not None
+
+    result = client.evaluate({})
+    assert result.evaluator_source == "fallback"
+
+
+def test_unreachable_vm_is_not_a_measured_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreachable backend must not be published as a legitimate 0.0."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=tmp_path,
+        require_waa_evaluators=False,
+    )
+
+    def _refuse(*_args, **_kwargs):
+        raise requests.ConnectionError("connection refused")
+
+    monkeypatch.setattr(requests, "post", _refuse)
+
+    result = client.evaluate(
+        {
+            "evaluator": {
+                "result": {"type": "file_content", "path": "C:/out.txt"},
+                "expected": {"value": "hello"},
+                "func": "exact_match",
+            }
+        }
+    )
+
+    assert result.score == 0.0
+    assert result.success is False
+    # The point of the fix: score 0.0 here is NOT a measurement.
+    assert result.scored is False
+    assert result.error_type == "infrastructure"
+    assert result.to_dict()["scored"] is False
+
+
+def test_vm_reported_command_error_is_not_an_empty_measurement(
+    tmp_path: Path,
+) -> None:
+    """A getter whose command failed must not be scored as empty output."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=tmp_path,
+        require_waa_evaluators=False,
+    )
+
+    with pytest.raises(EvaluationError):
+        client._require_output({"error": "WinError 5", "output": ""}, "file_content")
+
+
+def test_unknown_metric_name_is_not_silently_scored_with_exact_match(
+    tmp_path: Path,
+) -> None:
+    """Substituting a different metric publishes a number nobody requested."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=tmp_path,
+        require_waa_evaluators=False,
+    )
+
+    with pytest.raises(EvaluationError):
+        client._fallback_metric("check_csv_content", "a", "a")
+
+
+def test_known_metric_still_scores_normally(tmp_path: Path) -> None:
+    """The fix must not break the healthy path."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=tmp_path,
+        require_waa_evaluators=False,
+    )
+
+    assert client._fallback_metric("exact_match", "a", "a") == 1.0
+    assert client._fallback_metric("exact_match", "a", "b") == 0.0
+
+
+def test_missing_evaluator_config_is_flagged_not_scored(tmp_path: Path) -> None:
+    """A task with no evaluator spec was never measured."""
+    client = EvaluatorClient(
+        vm_ip="10.0.0.1",
+        waa_evaluators_path=tmp_path,
+        require_waa_evaluators=False,
+    )
+
+    result = client.evaluate({})
+    assert isinstance(result, EvaluationResult)
+    assert result.scored is False
+    assert result.error_type == "evaluation"

--- a/tests/test_false_success_sweep.py
+++ b/tests/test_false_success_sweep.py
@@ -1,0 +1,654 @@
+"""Regression tests for the "failure rendered as a successful empty result" class.
+
+Every test here pins a site where an operation that COULD NOT RUN used to
+produce a value indistinguishable from an operation that ran and found nothing.
+In an evaluation repo the consequence is not a crash but a wrong published
+number -- a backend that is unreachable, scored 0%, and reported as a
+legitimate 0%.
+
+Each test fails against the pre-fix implementation of its site.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from openadapt_types import BenchmarkAction, BenchmarkObservation, BenchmarkTask
+
+from openadapt_evals.adapters.base import (
+    BenchmarkResult,
+    EvaluationUnavailableError,
+)
+from openadapt_evals.adapters.rl_env import ResetConfig, RLEnvironment
+from openadapt_evals.harness.inspect_export import to_inspect_eval_log
+from openadapt_evals.harness.runner import MetaMetricsRow, run_meta
+
+
+def _task(task_id: str = "t1") -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id=task_id, instruction="do it", domain="test", raw_config={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# RLEnvironment.evaluate -- an unreachable VM is not a measured 0%
+# ---------------------------------------------------------------------------
+
+
+def _adapter(result: BenchmarkResult) -> MagicMock:
+    adapter = MagicMock()
+    adapter.list_tasks.return_value = [
+        _task()
+    ]
+    adapter.load_task.return_value = _task()
+    adapter.reset.return_value = BenchmarkObservation(screenshot=b"png")
+    adapter.observe.return_value = BenchmarkObservation(screenshot=b"png")
+    adapter.step.return_value = (BenchmarkObservation(screenshot=b"png"), False, {})
+    adapter.evaluate.return_value = result
+    return adapter
+
+
+class TestRLEnvironmentEvaluate:
+    def test_infrastructure_failure_raises_instead_of_returning_zero(self) -> None:
+        """WAALiveAdapter marks infra failures; flattening to float lost it."""
+        adapter = _adapter(
+            BenchmarkResult(
+                task_id="t1",
+                success=False,
+                score=0.0,
+                error_type="infrastructure",
+                reason="evaluate timed out after 3 retries",
+            )
+        )
+        env = RLEnvironment(adapter)
+        env.reset(ResetConfig(task_id="t1"))
+
+        with pytest.raises(EvaluationUnavailableError) as excinfo:
+            env.evaluate()
+
+        assert excinfo.value.error_type == "infrastructure"
+        assert "was not scored" in str(excinfo.value)
+
+    def test_genuine_zero_is_still_a_measurement(self) -> None:
+        """The fix must not turn real agent failures into exceptions."""
+        adapter = _adapter(
+            BenchmarkResult(task_id="t1", success=False, score=0.0, error_type=None)
+        )
+        env = RLEnvironment(adapter)
+        env.reset(ResetConfig(task_id="t1"))
+
+        assert env.evaluate() == 0.0
+
+    def test_evaluate_result_exposes_the_tristate(self) -> None:
+        adapter = _adapter(
+            BenchmarkResult(
+                task_id="t1", success=False, score=0.0, error_type="infrastructure"
+            )
+        )
+        env = RLEnvironment(adapter)
+        env.reset(ResetConfig(task_id="t1"))
+
+        result = env.evaluate_result()
+        assert result.error_type == "infrastructure"
+
+    def test_unmeasured_score_is_not_backfilled_as_a_reward(self) -> None:
+        """An infra 0.0 must never become a GRPO terminal reward."""
+        adapter = _adapter(
+            BenchmarkResult(
+                task_id="t1", success=False, score=0.0, error_type="infrastructure"
+            )
+        )
+        env = RLEnvironment(adapter)
+        env.reset(ResetConfig(task_id="t1"))
+        env.step(BenchmarkAction(type="click", x=1, y=1))
+        env.trajectory[-1].reward = -1.0  # sentinel
+
+        env.evaluate_result()
+
+        assert env.trajectory[-1].reward == -1.0, (
+            "an unscored evaluation overwrote the trajectory reward"
+        )
+
+    def test_per_step_eval_records_error_type_not_a_zero_score(self) -> None:
+        adapter = _adapter(
+            BenchmarkResult(
+                task_id="t1", success=False, score=0.0, error_type="infrastructure"
+            )
+        )
+        env = RLEnvironment(adapter, evaluate_every_step=True)
+        env.reset(ResetConfig(task_id="t1"))
+        step = env.step(BenchmarkAction(type="click", x=1, y=1))
+
+        assert "evaluation_score" not in step.info
+        assert step.info["evaluation_error_type"] == "infrastructure"
+
+
+# ---------------------------------------------------------------------------
+# harness.run_meta -- a crashed verifier said nothing, not "failed"
+# ---------------------------------------------------------------------------
+
+
+class _Env:
+    name = "testenv"
+
+    def __init__(self, verify_exc: Exception | None = None) -> None:
+        self._verify_exc = verify_exc
+
+    def reset(self, task):  # noqa: ANN001
+        return SimpleNamespace(screenshot=b"")
+
+    def verify(self, task):  # noqa: ANN001
+        if self._verify_exc is not None:
+            raise self._verify_exc
+        return SimpleNamespace(success=True, score=1.0, details={"source": "oracle"})
+
+
+def _policy(env, task, obs):  # noqa: ANN001
+    from openadapt_evals.harness.runner import PolicyOutcome
+
+    return PolicyOutcome(reported_success=True, num_steps=1)
+
+
+class TestRunMetaVerifier:
+    def test_verifier_crash_is_unscored_not_a_failed_task(self) -> None:
+        task = _task()
+        row = run_meta(_Env(RuntimeError("oracle unreachable")), task, _policy)
+
+        assert row.replay_success is None, (
+            "a verifier that crashed was recorded as a task the replay failed"
+        )
+        assert row.scored is False
+        assert row.verifier_score is None
+        assert "oracle unreachable" in (row.verifier_error or "")
+
+    def test_verify_error_survives_a_policy_error(self) -> None:
+        """`error = error or ...` used to discard the verify failure entirely."""
+
+        def _failing_policy(env, task, obs):  # noqa: ANN001
+            raise RuntimeError("policy blew up")
+
+        task = _task()
+        row = run_meta(_Env(RuntimeError("oracle unreachable")), task, _failing_policy)
+
+        assert "policy blew up" in (row.error or "")
+        assert "oracle unreachable" in (row.error or "")
+
+    def test_healthy_verify_still_scores(self) -> None:
+        task = _task()
+        row = run_meta(_Env(), task, _policy)
+
+        assert row.replay_success is True
+        assert row.scored is True
+        assert row.verifier_error is None
+
+
+class TestInspectExportAccuracy:
+    def _row(self, replay_success):  # noqa: ANN001, ANN202
+        return MetaMetricsRow(
+            env="e",
+            task_id=f"t{replay_success}",
+            mode="m",
+            replay_success=replay_success,
+            structural_rung_rate=0.0,
+            model_calls=0,
+            effect_verdict=None,
+            wall_ms=1.0,
+            cost_usd=0.0,
+        )
+
+    def test_unscored_rows_leave_the_accuracy_denominator(self) -> None:
+        rows = [self._row(True), self._row(False), self._row(None)]
+        doc = to_inspect_eval_log(rows)
+
+        metric = doc["results"]["scores"][0]["metrics"]["accuracy"]
+        # 1 of 2 SCORED, not 1 of 3.
+        assert metric["value"] == pytest.approx(0.5)
+        assert metric["scored_samples"] == 2
+        assert metric["unscored_samples"] == 1
+        assert doc["results"]["completed_samples"] == 2
+
+    def test_a_run_that_scored_nothing_is_not_a_zero_accuracy_success(self) -> None:
+        doc = to_inspect_eval_log([self._row(None), self._row(None)])
+
+        assert doc["results"]["scores"][0]["metrics"]["accuracy"]["value"] is None
+        assert doc["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Azure orchestrator -- a stub must not fabricate a 0% benchmark run
+# ---------------------------------------------------------------------------
+
+
+def test_azure_worker_results_stub_refuses_to_fabricate_scores() -> None:
+    from openadapt_evals.benchmarks.azure import (
+        AzureWAAOrchestrator,
+        WorkerState,
+    )
+
+    orchestrator = AzureWAAOrchestrator.__new__(AzureWAAOrchestrator)
+    worker = WorkerState(worker_id=0, compute_name="w0", assigned_tasks=["a", "b"])
+
+    with pytest.raises(NotImplementedError) as excinfo:
+        orchestrator._fetch_worker_results(worker)
+
+    assert "fabricate" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Azure ML health checks -- "could not look" is not "unhealthy"
+# ---------------------------------------------------------------------------
+
+
+class TestHealthChecker:
+    def _checker(self):  # noqa: ANN202
+        from openadapt_evals.benchmarks.health_checker import ContainerHealthChecker
+
+        ml_client = MagicMock()
+        ml_client.client.jobs.get.return_value = SimpleNamespace(status="Running")
+        return ContainerHealthChecker(ml_client)
+
+    def test_log_stub_raises_instead_of_returning_an_empty_log(self) -> None:
+        from openadapt_evals.benchmarks.health_checker import JobLogsUnavailableError
+
+        with pytest.raises(JobLogsUnavailableError):
+            self._checker()._get_job_logs("job-1")
+
+    def test_unreadable_logs_give_an_unknown_verdict_not_unhealthy(self) -> None:
+        result = self._checker().check_container_running("job-1")
+
+        assert result.healthy is None, (
+            "an unreadable log was reported as a container health failure"
+        )
+        assert result.known is False
+
+    def test_stuck_detector_does_not_cancel_on_an_unknown_verdict(self) -> None:
+        from openadapt_evals.benchmarks.health_checker import StuckJobDetector
+
+        ml_client = MagicMock()
+        ml_client.client.jobs.get.return_value = SimpleNamespace(status="Running")
+        detector = StuckJobDetector(ml_client)
+
+        is_stuck, message = detector.check_and_handle_stuck_job(
+            "job-1", auto_cancel=True,
+        )
+
+        assert is_stuck is False
+        assert "NOT checked" in message
+        ml_client.client.jobs.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Resource tracker -- "could not ask Azure" must not read as "$0 running"
+# ---------------------------------------------------------------------------
+
+
+class TestResourceTracker:
+    def test_az_failure_raises_rather_than_returning_no_vms(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from openadapt_evals.infrastructure import resource_tracker
+
+        monkeypatch.setattr(
+            resource_tracker.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="az login"),
+        )
+
+        with pytest.raises(resource_tracker.AzureQueryFailed):
+            resource_tracker.get_azure_vms()
+
+    def test_report_says_unknown_not_all_deallocated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from openadapt_evals.infrastructure import resource_tracker
+
+        monkeypatch.setattr(
+            resource_tracker.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(
+                returncode=1, stdout="", stderr="az: command not found"
+            ),
+        )
+        monkeypatch.setattr(resource_tracker, "get_paused_pool", lambda: None)
+
+        status = resource_tracker.check_resources()
+        assert status["query_failures"], "a failed az query left no trace"
+
+        written: dict[str, str] = {}
+        monkeypatch.setattr(
+            resource_tracker.Path,
+            "write_text",
+            lambda self, text, *a, **k: written.setdefault("body", text),
+        )
+        resource_tracker.update_resources_file(status)
+
+        body = written["body"]
+        assert "All Azure resources are deallocated or stopped." not in body
+        assert "UNKNOWN" in body
+
+    def test_healthy_query_still_reports_no_running_resources(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from openadapt_evals.infrastructure import resource_tracker
+
+        monkeypatch.setattr(
+            resource_tracker.subprocess,
+            "run",
+            lambda *a, **k: SimpleNamespace(
+                returncode=0, stdout=json.dumps([]), stderr=""
+            ),
+        )
+        monkeypatch.setattr(resource_tracker, "get_paused_pool", lambda: None)
+
+        status = resource_tracker.check_resources()
+        assert status["query_failures"] == []
+
+
+# ---------------------------------------------------------------------------
+# AWS auto-shutdown -- a "success" boolean derived from a checked outcome
+# ---------------------------------------------------------------------------
+
+
+def test_set_auto_shutdown_reports_failure_when_the_command_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openadapt_evals.infrastructure import aws_vm, azure_vm
+
+    manager = aws_vm.AWSVMManager.__new__(aws_vm.AWSVMManager)
+    monkeypatch.setattr(
+        aws_vm.AWSVMManager, "ssh_username", property(lambda self: "ubuntu"),
+    )
+    monkeypatch.setattr(
+        aws_vm.AWSVMManager, "get_vm_ip", lambda self, name: "1.2.3.4",
+    )
+    monkeypatch.setattr(
+        azure_vm,
+        "ssh_run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="sudo: a terminal is required"
+        ),
+    )
+
+    assert manager.set_auto_shutdown("vm-1", hours=4) is False, (
+        "the cost safety net reported itself armed without checking"
+    )
+
+
+def test_set_auto_shutdown_reports_success_when_the_command_succeeded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openadapt_evals.infrastructure import aws_vm, azure_vm
+
+    manager = aws_vm.AWSVMManager.__new__(aws_vm.AWSVMManager)
+    monkeypatch.setattr(
+        aws_vm.AWSVMManager, "ssh_username", property(lambda self: "ubuntu"),
+    )
+    monkeypatch.setattr(
+        aws_vm.AWSVMManager, "get_vm_ip", lambda self, name: "1.2.3.4",
+    )
+    monkeypatch.setattr(
+        azure_vm,
+        "ssh_run",
+        lambda *a, **k: subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="Shutdown scheduled", stderr=""
+        ),
+    )
+
+    assert manager.set_auto_shutdown("vm-1", hours=4) is True
+
+
+# ---------------------------------------------------------------------------
+# Parallels ground-truth verifiers
+# ---------------------------------------------------------------------------
+
+
+class _FakeVM:
+    def __init__(self, stdout: str = "", returncode: int = 0) -> None:
+        self._stdout = stdout
+        self._returncode = returncode
+
+    def exec_ps(self, cmd):  # noqa: ANN001
+        return SimpleNamespace(
+            stdout=self._stdout, returncode=self._returncode, stderr="boom"
+        )
+
+    exec_cmd = exec_ps
+
+
+class _TasklistVM:
+    """A VM whose `tasklist` behaves like the real one.
+
+    Windows ANDs multiple ``/FI`` filters, so a command asking for
+    ``IMAGENAME eq CalculatorApp.exe`` AND ``IMAGENAME eq Calculator.exe`` can
+    never match a process. A fake that echoes fixed stdout regardless of the
+    command hides that -- which is exactly why the original bug survived its
+    own test.
+    """
+
+    def __init__(self, running: str) -> None:
+        self.running = running
+        self.commands: list[str] = []
+
+    def exec_cmd(self, cmd):  # noqa: ANN001
+        self.commands.append(cmd)
+        wanted = re.findall(r"IMAGENAME eq ([^\"]+)", cmd)
+        if len(wanted) == 1 and wanted[0] == self.running:
+            out = (
+                "Image Name                     PID Session Name\n"
+                f"{self.running}                4242 Console\n"
+            )
+        else:
+            out = "INFO: No tasks are running which match the specified criteria."
+        return SimpleNamespace(stdout=out, returncode=0, stderr="")
+
+    exec_ps = exec_cmd
+
+
+class TestParallelsVerifiers:
+    def test_calculator_check_can_actually_pass(self) -> None:
+        """`tasklist` ANDs /FI filters, so the old command could never match."""
+        from openadapt_evals.flow.parallels_env import verify_calculator_open
+
+        vm = _TasklistVM(running="CalculatorApp.exe")
+        ok, _ = verify_calculator_open(vm)
+
+        assert ok is True, (
+            "verify_calculator_open cannot return True against a real "
+            "tasklist, so this task's verified success rate is pinned at 0%"
+        )
+        # Each probe must carry exactly one IMAGENAME filter.
+        for cmd in vm.commands:
+            assert len(re.findall(r"IMAGENAME eq", cmd)) == 1
+
+    def test_calculator_check_still_reports_a_genuine_absence(self) -> None:
+        from openadapt_evals.flow.parallels_env import verify_calculator_open
+
+        ok, _ = verify_calculator_open(_TasklistVM(running="notepad.exe"))
+        assert ok is False
+
+    def test_dead_exec_channel_is_unscored_not_a_failed_task(self) -> None:
+        from openadapt_evals.flow.parallels_env import (
+            verify_calculator_open,
+            verify_notepad_file,
+        )
+
+        vm = _FakeVM(stdout="", returncode=255)
+        assert verify_notepad_file(vm)[0] is None
+        assert verify_calculator_open(vm)[0] is None
+
+    def test_runner_records_an_unscored_verdict_as_unscored(self, tmp_path) -> None:  # noqa: ANN001
+        """`bool(verified)` turned the None sentinel into a measured failure."""
+        from openadapt_evals.flow.replay_runner import (
+            FlowTask,
+            aggregate_replay_metrics,
+            run_demonstrate_then_replay,
+        )
+
+        bundle = tmp_path / "bundle"
+        bundle.mkdir()
+
+        def replay_fn(bundle_dir, server_url, run_dir, params):  # noqa: ANN001
+            return SimpleNamespace(
+                success=True,
+                terminal_outcome="success",
+                rung_counts={"primary": 1},
+                heal_count=0,
+                model_calls=0,
+                est_model_cost_usd=0.0,
+                total_ms=1.0,
+                results=[object()],
+            )
+
+        def evaluator(task_id):  # noqa: ANN001
+            return None, "exec channel dead (exit 255)"
+
+        metrics = run_demonstrate_then_replay(
+            [FlowTask("t1", bundle_dir=bundle)],
+            "http://localhost:5001",
+            tmp_path / "runs",
+            replay_fn=replay_fn,
+            evaluator=evaluator,
+        )
+
+        assert metrics[0].waa_verified_success is None, (
+            "a verifier that could not run was recorded as a failed task"
+        )
+        agg = aggregate_replay_metrics(metrics)
+        assert agg["waa_verified_num_scored"] == 0
+        assert agg["waa_verified_success_rate"] is None
+
+    def test_unscored_verdict_leaves_the_success_rate_denominator(self) -> None:
+        from openadapt_evals.flow.replay_runner import (
+            PerTaskReplayMetrics,
+            aggregate_replay_metrics,
+        )
+
+        def _m(task_id: str, verified):  # noqa: ANN001, ANN202
+            return PerTaskReplayMetrics(
+                task_id=task_id,
+                bundle_dir=None,
+                waa_verified_success=verified,
+                replay_reported_success=False,
+                structural_rung_counts={},
+                structural_rung_fire_total=0,
+                rung_fire_rate=0.0,
+                model_calls=0,
+                est_model_cost_usd=0.0,
+                wall_clock_s=0.0,
+                heal_count=0,
+                halted=False,
+                terminal_outcome="success",
+                num_steps=1,
+            )
+
+        metrics = [_m("a", True), _m("b", None)]
+        agg = aggregate_replay_metrics(metrics)
+        assert agg["waa_verified_success_rate"] == pytest.approx(1.0)
+        assert agg["waa_verified_num_scored"] == 1
+
+
+# ---------------------------------------------------------------------------
+# WAA /evaluate endpoint -- an unreachable VM is not a 0% task
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateEndpointNotScored:
+    def test_missing_getter_is_not_scored(self) -> None:
+        from openadapt_evals.server.evaluate_endpoint import (
+            EvaluationNotRunError,
+            get_actual_value,
+        )
+
+        with pytest.raises(EvaluationNotRunError):
+            get_actual_value(
+                {"result": {"type": "totally_unknown_thing"}},
+                env=MagicMock(),
+                getters=SimpleNamespace(),
+            )
+
+    def test_getter_that_raises_is_infrastructure_not_a_failed_task(self) -> None:
+        from openadapt_evals.server.evaluate_endpoint import (
+            EvaluationNotRunError,
+            get_actual_value,
+        )
+
+        def _boom(env, spec):  # noqa: ANN001
+            raise ConnectionError("172.30.0.2 refused")
+
+        with pytest.raises(EvaluationNotRunError) as excinfo:
+            get_actual_value(
+                {"result": {"type": "thing"}},
+                env=MagicMock(),
+                getters=SimpleNamespace(get_thing=_boom),
+            )
+        assert excinfo.value.error_type == "infrastructure"
+
+    def test_unknown_metric_is_not_silently_swapped_for_exact_match(self) -> None:
+        from openadapt_evals.server.evaluate_endpoint import (
+            EvaluationNotRunError,
+            run_metric,
+        )
+
+        metrics = SimpleNamespace(exact_match=lambda a, b: 1.0)
+        with pytest.raises(EvaluationNotRunError):
+            run_metric("check_csv_content", "a", "a", {}, metrics)
+
+    def test_evaluate_task_state_marks_the_row_unscored(self) -> None:
+        from openadapt_evals.server import evaluate_endpoint
+
+        def _boom(env, spec):  # noqa: ANN001
+            raise ConnectionError("172.30.0.2 refused")
+
+        getters = SimpleNamespace(get_thing=_boom)
+        metrics = SimpleNamespace(exact_match=lambda a, b: 1.0)
+
+        # Inject the evaluators so the loader is not consulted.
+        evaluate_endpoint._getters_module = getters
+        evaluate_endpoint._metrics_module = metrics
+        try:
+            result = evaluate_endpoint.evaluate_task_state(
+                {
+                    "evaluator": {
+                        "result": {"type": "thing"},
+                        "expected": {"value": "x"},
+                    }
+                },
+                env=MagicMock(),
+            )
+        finally:
+            evaluate_endpoint._getters_module = None
+            evaluate_endpoint._metrics_module = None
+
+        assert result["scored"] is False
+        assert result["error_type"] == "infrastructure"
+
+
+def test_live_adapter_does_not_accept_an_unscored_200_as_a_result() -> None:
+    """A 200 body carrying `scored: false` must not become a measured 0.0."""
+    from openadapt_evals.adapters.waa.live import WAALiveAdapter
+
+    adapter = WAALiveAdapter.__new__(WAALiveAdapter)
+    adapter._step_count = 3
+
+    task = _task()
+    result = adapter._result_from_evaluate_response(
+        task,
+        {
+            "success": False,
+            "score": 0.0,
+            "scored": False,
+            "error_type": "infrastructure",
+            "reason": "getter could not run on the VM",
+        },
+    )
+    assert result.error_type == "infrastructure"
+
+    measured = adapter._result_from_evaluate_response(
+        task, {"success": False, "score": 0.0, "scored": True, "error_type": None},
+    )
+    assert measured.error_type is None

--- a/tests/test_http_agent.py
+++ b/tests/test_http_agent.py
@@ -86,31 +86,36 @@ class TestAct:
 
     @patch("openadapt_evals.agents.http_agent.requests.post")
     def test_act_connection_error(self, mock_post, agent, observation, task):
-        """act() returns done with error info on connection failure."""
+        """act() returns an infrastructure error, never a clean `done`."""
         import requests
 
         mock_post.side_effect = requests.ConnectionError("refused")
 
         action = agent.act(observation, task)
 
-        assert action.type == "done"
+        # NOT "done": an unreachable agent endpoint is an infrastructure
+        # failure, and `done` reads to the eval loop as a clean agent finish,
+        # producing a genuine-looking 0% for an agent that never ran.
+        assert action.type == "error"
+        assert action.raw_action["error_type"] == "infrastructure"
         assert "connection_failed" in action.raw_action["error"]
 
     @patch("openadapt_evals.agents.http_agent.requests.post")
     def test_act_timeout(self, mock_post, agent, observation, task):
-        """act() returns done with error info on timeout."""
+        """act() returns an infrastructure error on timeout, never done."""
         import requests
 
         mock_post.side_effect = requests.Timeout("timed out")
 
         action = agent.act(observation, task)
 
-        assert action.type == "done"
+        assert action.type == "error"
+        assert action.raw_action["error_type"] == "infrastructure"
         assert "timeout" in action.raw_action["error"]
 
     @patch("openadapt_evals.agents.http_agent.requests.post")
     def test_act_http_error(self, mock_post, agent, observation, task):
-        """act() returns done with error info on HTTP error."""
+        """act() returns an infrastructure error on HTTP error, never done."""
         import requests
 
         mock_resp = MagicMock()
@@ -119,7 +124,8 @@ class TestAct:
 
         action = agent.act(observation, task)
 
-        assert action.type == "done"
+        assert action.type == "error"
+        assert action.raw_action["error_type"] == "infrastructure"
         assert "http_error" in action.raw_action["error"]
 
     @patch("openadapt_evals.agents.http_agent.requests.post")
@@ -250,9 +256,11 @@ class TestParseActionResponse:
         assert action.target_node_id == "btn_42"
         assert action.target_role == "button"
 
-    def test_missing_type_defaults_to_done(self):
+    def test_missing_type_is_an_error_not_a_clean_finish(self):
+        """A body with no `type` is malformed, not a completed task."""
         action = _parse_action_response({})
-        assert action.type == "done"
+        assert action.type == "error"
+        assert action.raw_action["error_type"] == "agent"
 
     def test_raw_action_preserved(self):
         data = {"type": "click", "x": 0.5, "y": 0.5, "extra_field": "kept"}


### PR DESCRIPTION
## The named defect: logged, not fixed

`openadapt_evals/evaluation/client.py` — `EvaluatorClient._load_evaluators` swallowed `ImportError`, so a **broken** WAA evaluators install and a **healthy** one produced the same client, and every later run was silently scored by the built-in fallback evaluator.

PR #275 added this:

```python
except ImportError as e:
    logger.warning(
        "WAA evaluators not importable from %s (%s); "
        "falling back to built-in evaluation", ...)
```

…and returned the same fallback-configured client. **That is not a fix** — a logged failure that still returns a success-shaped value is the same bug with better documentation. A caller still cannot tell a broken install from a deliberate absence, and every downstream evaluation is still computed with the wrong evaluator.

The distinction is now representable:

- `EvaluatorsUnavailableError` raised at construction by default.
- `require_waa_evaluators=False` to opt into fallback scoring **deliberately** — and then every result is stamped `evaluator_source="fallback"`.
- Absent-vs-broken are worded differently, so you can tell "not installed" from "installed and broken".
- `EvaluationResult` gained `error_type` / `scored`.

Same file, same class: an unreachable VM used to return `reason='Metric returned score 0.0'`; a failed VM command was read as empty output; an unknown metric name was silently rescored with `exact_match`.

**Deliberate optional-dependency probes were left alone.** The `except ImportError` blocks guarding torch / transformers / trl / peft / unsloth / wandb / azure-sdk degrade correctly and never produce a number. The defect is only where a *broken or required* component is indistinguishable from a *legitimately absent optional* one, or where the degraded path emits a metric.

## Sweep, ranked by blast radius

This is an evaluation repo: a swallowed failure here does not crash something, it **publishes a wrong number**.

| # | Site | What it published |
|---|---|---|
| 1 | `adapters/rl_env.py` `evaluate()` | Flattened `BenchmarkResult` to a float, discarding the `error_type` adapters take real trouble to set. 40 tasks whose VM stopped answering were published as 40 genuine agent failures. |
| 2 | `adapters/rl_env.py` `evaluate_dense()` | `except Exception: binary_score = 0.0` published the milestone high-water mark as a task score when the evaluator was down. |
| 3 | `scripts/compare_models.py` | No infra bucket at all — a model whose SGLang server failed to start scored `0.00` cells against one whose server came up. A pure-infrastructure delta rendered as a capability delta. |
| 4 | `harness/runner.py` `run_meta` | A **crashed** verifier was recorded as `replay_success=False, verifier_score=0.0`; `error = error or ...` discarded the verify error entirely when the policy had also failed. `inspect_export` then computed `accuracy = correct/total` over those rows and stamped the document `"status": "success"`. |
| 5 | `benchmarks/azure.py` `_fetch_worker_results` | A stub that synthesized one zero-score `BenchmarkResult` per task, with no `error`/`error_type`/`reason` — so `compute_metrics` could not even filter it — producing a complete, legitimate-looking `Success rate: 0.0%` for a run that never touched a VM. |
| 6 | `server/evaluate_endpoint.py` | A dead VM answered HTTP 200 with `{"success": false, "score": 0.0}`. **This is the "unreachable backend scores 0%" case, published as a real result.** Also: an unknown metric name silently fell back to `exact_match` and scored the task anyway. |
| 7 | `benchmarks/health_checker.py` | `_get_job_logs` was a stub returning `""`, so every verdict derived from it was a false negative. `StuckJobDetector(auto_cancel=True)` would cancel **every healthy job it looked at**, and `wait_for_container_start` could never succeed. |
| 8 | `infrastructure/resource_tracker.py` | `[]` on `az` failure → RESOURCES.md asserted *"All Azure resources are deallocated or stopped"* while VMs billed. |
| 9 | `infrastructure/aws_vm.py` | `set_auto_shutdown` returned `True` without inspecting the SSH result — a cost safety net reporting itself armed without checking. |
| 10 | `agents/http_agent.py` | Returned `type="done"` on connection failure, which the eval loop reads as a clean agent finish. A sidecar that OOMed at step 0 yielded 154 tasks of "agent scored 0%" with the agent never having run. |
| 11 | `flow/parallels_env.py` | `verify_calculator_open` ANDed two `IMAGENAME` filters (`tasklist` ANDs them), so it **could never return True** — that task's verified success rate was pinned at 0% regardless of ground truth. The verifiers also discarded `returncode`, turning a dead exec channel into a measured task failure. |
| 12 | `scripts/check_published_evidence_freshness.py` | Printed *"is bound to the current release"* after **skipping** that comparison. In a CI log where only the last line is read, an unreachable PyPI read as a passing freshness check — precisely the failure this script exists to catch. |

Each is repaired by making the state representable — a raised exception, a tri-state, or an explicit `error_type` the caller must handle — not by adding a log line.

## Judged NOT defects

- All `except ImportError` optional-dependency probes (heavy ML packages, Flask, azure-sdk, VAGEN) — they degrade correctly and never emit a number.
- `flow/replay_runner.py` + `aggregate_replay_metrics` — already the reference pattern (`None` for unscored, excluded from the denominator, rate `None` rather than `0.0`). It is the model the other fixes follow.
- `benchmarks/runner.py::compute_metrics` + `data_collection.save_summary` — already separate infra failures and publish `*_excluding_infra`.
- `harness/external.py` — phase-2 stubs already raise `NotImplementedError` rather than returning plausible zeros. The right way to stub a scorer.
- `harness/adapters.py::_verdict_to_result` — INDETERMINATE scores 0.0 but preserves the three-valued verdict in `details`.
- `health_check()` / `check_ssh()` style probes returning `False` — "probed, did not get a healthy answer" is the honest answer to the question they ask, and it is not used as a score.

## Fake-gate audit

`.github/workflows/` grepped for `|| true`, `continue-on-error`, `exit 0`, `set +e`, and swallowed step failures: **nothing found**. All four workflows (`test`, `release`, `evidence-freshness`, `notify-docs`) fail loudly. `release.yml` even files an issue on failure. No gate needed repair.

## Mutation check

Every regression test was mutation-checked by reverting the production file to `origin/main` and re-running.

- Named defect, with PR #275's log-only behaviour restored — the test still fails, and pytest captures #275's own warning line next to the failure:
  ```
  E  Failed: DID NOT RAISE <class '...EvaluatorsUnavailableError'>
  ------------------------------ Captured log call -------------------------------
  WARNING  ...client.py:157 WAA evaluators found at .../desktop_env but not
  importable (cannot import name 'getters' from 'evaluators') -- the install is
  broken, not absent. falling back to built-in evaluation
  ```
- The unreachable-VM test against `origin/main`:
  ```
  E  AssertionError: assert True is False
  E   +  where True = EvaluationResult(success=False, score=0.0, actual='',
       expected='hello', reason='Metric returned score 0.0', error_type=None).scored
  ```
  `reason='Metric returned score 0.0'` — for a VM that refused the connection.
- Sweep suite with all 11 production files reverted to `origin/main`: **23 of 29 fail**. The 6 that pass are deliberate controls pinning the healthy path (a genuine 0.0 is still a measurement; a successful `shutdown` still returns True).

Tests: `tests/test_evaluator_client_failure_visibility.py` (8), `tests/test_false_success_sweep.py` (29).

## Verification (locally, exactly as CI does)

- `uv sync --locked --extra dev --no-sources` ✅
- heavy-import guard ✅
- `python scripts/check_published_evidence_freshness.py --offline` ✅
- `uv run --no-sources ruff check .` ✅
- CI pytest invocation: **1696 passed, 54 skipped, 17 deselected** ✅

`tests/test_http_agent.py` was updated: four of its assertions codified the defect (`test_missing_type_defaults_to_done`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NyCHrzA1psrKMFfroYbzaM