### PR TITLE
ci: run pull-request checks on every base branch

### DIFF
--- a/.github/workflows/complex-visual.yml
+++ b/.github/workflows/complex-visual.yml
@@ -2,7 +2,6 @@ name: complex-visual
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - benchmark/complex_visual/**
       - tests/test_complex_visual_campaign.py

--- a/.github/workflows/evidence-freshness.yml
+++ b/.github/workflows/evidence-freshness.yml
@@ -9,7 +9,6 @@ on:
     - cron: '17 6 * * *'
   workflow_dispatch:
   pull_request:
-    branches: [main]
     paths:
       - 'docs/eval_results/**'
       - 'scripts/check_published_evidence_freshness.py'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## The problem

A stacked pull request gets **zero checks** and still reports `mergeStateStatus: CLEAN`.

PR #287 targets `codex/production-evidence-contract`, not `main`. Every `pull_request` trigger in this repository is filtered to `branches: [main]`, so no workflow matched and nothing ran. Its test numbers came from a local run only.

An unverified pull request is indistinguishable from a passing one in the UI and in `gh pr view`. That is how an untested change reaches `main`.

| PR | base | checks |
|---|---|---|
| openadapt-evals#287 | `codex/production-evidence-contract` | **0** |
| openadapt-capture#78 | `codex/promote-capture-beta` | **1** |
| openadapt-flow#372 | `codex/push-json-contract` | 15 |

openadapt-flow#372 gets full CI because Flow's `ci.yml` carries no base filter. That confirms the mechanism.

## The change

Remove the base-branch filter from the three `pull_request` triggers. The `push` trigger keeps `branches: [main]`.

## Cost

`complex-visual` and `evidence-freshness` keep their `paths` filters, so extra runs happen only when a stacked pull request touches those paths. `test` runs on every pull request, which is the intent.

A matching change is needed in `openadapt-capture`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)