### PR TITLE
fix(ci): publish with an action that accepts Metadata-Version 2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,14 @@ jobs:
         if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
         run: python scripts/check_source_boundary.py --require-dist
 
+      # v1.14.0 bundles twine 6.1.0 and packaging 25.0, which reject the
+      # Metadata-Version 2.5 that current hatchling emits. That failed the
+      # 0.91.0 publish after the tag, the release commit and the GitHub
+      # release had already landed. v1.14.2 bundles twine 7.0.0 and packaging
+      # 26.2, and is the same pin openadapt-flow and openadapt-capture use.
       - name: Publish to PyPI
         if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
       - name: Publish to GitHub Releases
         if: steps.check_skip.outputs.skip != 'true' && steps.release.outputs.released == 'true'


### PR DESCRIPTION
## The problem

The 0.91.0 release created the tag `v0.91.0`, pushed the `chore: release 0.91.0` commit to `main`, and published the GitHub release, then failed at **Publish to PyPI**:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

PyPI therefore still serves `openadapt-evals` 0.90.3, and `main` is red. Failure run: https://github.com/OpenAdaptAI/openadapt-evals/actions/runs/32306043421 (tracked by #290).

## The cause

Current hatchling emits `Metadata-Version: 2.5`. The pinned `pypa/gh-action-pypi-publish` v1.14.0 (`cef22109`) bundles `twine==6.1.0` and `packaging==25.0`, which do not know that metadata version. v1.14.2 (`dc37677b`) bundles `twine==7.0.0` and `packaging==26.2`.

`openadapt-flow` and `openadapt-capture` already pin `dc37677b`.

## The change

Bumps the pin to v1.14.2 and records why. Nothing else changes; the artifact itself is unaffected.

This is a `fix` commit, so semantic release cuts 0.91.1 and publishes it with the corrected action, which closes the PyPI gap left by 0.91.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)