### PR TITLE
fix(evidence): expect private Cloud source visibility at signing

### DIFF
--- a/docs/eval_results/PRODUCTION_READINESS.md
+++ b/docs/eval_results/PRODUCTION_READINESS.md
@@ -52,9 +52,13 @@ does not contain tenant or workflow identifiers.
 
 The verifier asks GitHub CLI to verify the certificate against the exact
 `OpenAdaptAI/openadapt-cloud` workflow on `refs/heads/main`, the GitHub Actions
-OIDC issuer, and a GitHub-hosted runner. It then validates the verified SLSA
-provenance. It refuses an unknown repository, workflow, ref, source digest,
-issuer, runner class, signature, or empty verification result.
+OIDC issuer, and a GitHub-hosted runner. That repository is the proprietary
+hosted control plane and stays private, so the verifier also requires
+`sourceRepositoryVisibilityAtSigning` to equal `private`. A certificate signed
+in a public source repository is not the reviewed Cloud workflow. The verifier
+then validates the verified SLSA provenance. It refuses an unknown repository,
+workflow, ref, source digest, issuer, runner class, signature, or empty
+verification result.
 
 The expected Cloud commit is an external reviewer input. The importer requires
 the certificate commit, the GitHub signing-certificate source commit, and the

--- a/scripts/import_production_acceptance.py
+++ b/scripts/import_production_acceptance.py
@@ -2719,7 +2719,7 @@ def _validate_verified_provenance(
         "buildConfigDigest": expected_cloud_source_commit,
         "buildTrigger": "workflow_dispatch",
         "runInvocationURI": expected_invocation,
-        "sourceRepositoryVisibilityAtSigning": "public",
+        "sourceRepositoryVisibilityAtSigning": "private",
     }
     for key, expected in expected_certificate_fields.items():
         if certificate.get(key) != expected:

--- a/tests/test_import_production_acceptance.py
+++ b/tests/test_import_production_acceptance.py
@@ -512,7 +512,7 @@ def _verified_provenance(
                             "https://github.com/OpenAdaptAI/openadapt-cloud/"
                             "actions/runs/123456789/attempts/1"
                         ),
-                        "sourceRepositoryVisibilityAtSigning": "public",
+                        "sourceRepositoryVisibilityAtSigning": "private",
                     }
                 },
                 "verifiedTimestamps": [
@@ -1710,6 +1710,11 @@ def test_verifier_allows_other_subjects_but_only_one_matching_certificate(
             "runInvocationURI is not approved",
         ),
         ("buildConfigDigest", "0" * 40, "buildConfigDigest is not approved"),
+        (
+            "sourceRepositoryVisibilityAtSigning",
+            "public",
+            "sourceRepositoryVisibilityAtSigning is not approved",
+        ),
     ],
 )
 def test_verifier_rejects_real_gh_certificate_policy_drift(


### PR DESCRIPTION
## Problem

`_validate_verified_provenance` in [scripts/import_production_acceptance.py](scripts/import_production_acceptance.py:2722) required the GitHub signing-certificate field `sourceRepositoryVisibilityAtSigning` to equal `"public"`.

The repository it verifies against is `CLOUD_REPOSITORY = "OpenAdaptAI/openadapt-cloud"`, which is private:

```
$ gh repo view OpenAdaptAI/openadapt-cloud --json visibility
{"visibility":"PRIVATE"}
```

A real GitHub artifact attestation produced in a private repository carries `"private"`, so a genuine certificate would always have been refused.

The path is currently unreachable: `import_files()` refuses every import with `"full admission/campaign import is pending an approved private-export contract"`, and it fails closed. No released behaviour changes. The defect had to be fixed before the private-export gate opens.

## Decision: option 1 — the workflow stays private

The acceptance workflow stays in the private `openadapt-cloud` repository, so the expected value becomes `"private"`. Evidence for that reading:

- `openadapt-cloud` is the proprietary hosted control plane under the workspace source-availability boundary. Publishing it is out of the question, so option 2 would mean splitting the acceptance workflow out to a new public repository.
- `.github/workflows/execute-live-acceptance.yml` already exists on `openadapt-cloud` `main` and on `codex/native-admission-cloud`. It runs in the `production` environment on production-scoped secrets (bearer tokens, webhook signing secret, qualification IDs) and checks out the Cloud source to run `scripts/execute-live-acceptance.mjs`. That workflow cannot move to a public repository without exposing the production acceptance wiring.
- `docs/eval_results/PRODUCTION_READINESS.md` already states the verifier binds "the exact `OpenAdaptAI/openadapt-cloud` workflow on `refs/heads/main`". `CLOUD_REPOSITORY` and `CLOUD_CERTIFICATE_IDENTITY` therefore stay as they are.

The Cloud track can still object — the constants and the expected value are one line each — but nothing in the Cloud branch points toward a public host.

## Changes

- `scripts/import_production_acceptance.py`: expected `sourceRepositoryVisibilityAtSigning` is now `"private"`. The comparison stays exact and fail-closed; no other expected field, gate, or constant changed.
- `tests/test_import_production_acceptance.py`: the `_verified_provenance` fixture now carries `"private"`, and `test_verifier_rejects_real_gh_certificate_policy_drift` gains a case asserting that `"public"` is refused, so the gate cannot regress silently.
- `docs/eval_results/PRODUCTION_READINESS.md`: records why the verifier requires private visibility.

## Verification

- 229 tests pass in `tests/test_import_production_acceptance.py`.
- Mutation check: deleting the `sourceRepositoryVisibilityAtSigning` entry fails the new drift case; restoring it passes. The test guards the gate rather than restating it.
- `ruff check .` passes.

## Follow-up for the Cloud track (not fixed here)

Two further items must be settled before the private-export gate opens. Neither is touched by this PR.

1. **Transparency-log check.** [scripts/import_production_acceptance.py:2738](scripts/import_production_acceptance.py:2738) requires exactly one verified timestamp of `type: "Tlog"` at `uri: "https://rekor.sigstore.dev"`. Attestations from private repositories are not signed by the public-good Sigstore instance: GitHub uses its own internal Fulcio and its own timestamp authority in place of Rekor. A genuine private-repository attestation is therefore likely to fail this check too — the same class of defect as the one fixed here. Resolving it needs the exact `type` and `uri` from a real `gh attestation verify --format json` run against `openadapt-cloud`, so it is not guessed here.
2. **The attestation does not exist yet.** No `attest-build-provenance` step exists anywhere in `openadapt-cloud` (`search/code` for `attest-build-provenance` in that repository returns 0 hits). The Cloud workflow must be extended to sign the certificate bytes, with `id-token: write` and `attestations: write`, before any of this verification path can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)